### PR TITLE
refactor: invalid json handler exception handling

### DIFF
--- a/src/main/java/io/vanslog/spring/data/meilisearch/config/JsonHandlerBuilder.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/config/JsonHandlerBuilder.java
@@ -28,4 +28,13 @@ public enum JsonHandlerBuilder {
   };
 
   public abstract JsonHandler build();
+
+  public static boolean contains(String name) {
+    for (JsonHandlerBuilder builder : JsonHandlerBuilder.values()) {
+      if (builder.name().equals(name)) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchClientBeanDefinitionParser.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchClientBeanDefinitionParser.java
@@ -1,10 +1,12 @@
 package io.vanslog.spring.data.meilisearch.config;
 
 import io.vanslog.spring.data.meilisearch.client.MeilisearchClientFactoryBean;
+import java.util.Arrays;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.Assert;
 import org.w3c.dom.Element;
 
 /**
@@ -31,11 +33,11 @@ public class MeilisearchClientBeanDefinitionParser extends AbstractBeanDefinitio
 		builder.addPropertyValue("clientAgents", element.getAttribute("client-agents"));
 
 		String jsonHandlerName = element.getAttribute("json-handler");
-		JsonHandlerBuilder handlerBuilder = JsonHandlerBuilder.valueOf(jsonHandlerName.toUpperCase());
+		Assert.isTrue(JsonHandlerBuilder.contains(jsonHandlerName),
+				"JsonHandler must be one of " + Arrays.toString(JsonHandlerBuilder.values()));
 
-		if (handlerBuilder != null) {
-			builder.addPropertyValue("jsonHandler", handlerBuilder.build());
-		}
+		JsonHandlerBuilder handlerBuilder = JsonHandlerBuilder.valueOf(jsonHandlerName.toUpperCase());
+		builder.addPropertyValue("jsonHandler", handlerBuilder.build());
 	}
 
 	private AbstractBeanDefinition getSourcedBeanDefinition(BeanDefinitionBuilder builder, Element source,


### PR DESCRIPTION
Fixed to raise an error if the handler specified something other than `GSON` and `JACKSON`.