### PR TITLE
fix: replace javadoc in document annotation

### DIFF
--- a/src/main/java/io/vanslog/spring/data/meilisearch/annotations/Document.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/annotations/Document.java
@@ -7,16 +7,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.springframework.data.annotation.Persistent;
 
-@Persistent
-@Inherited
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE})
 /**
  * Identifies a domain object to be persisted to Meilisearch.
  *
  * @since 1.0.0
  * @auther Junghoon Ban
  */
+
+@Persistent
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
 public @interface Document {
   String indexUid();
 }


### PR DESCRIPTION
Fix invalid javadoc declarations.

## AS-IS

```java
@Persistent
@Inherited
@Retention(RetentionPolicy.RUNTIME)
@Target({ElementType.TYPE})
/**
 * Identifies a domain object to be persisted to Meilisearch.
 *
 * @since 1.0.0
 * @auther Junghoon Ban
 */
public @interface Document {
  String indexUid();
}
```

## TO-BE

```java
/**
 * Identifies a domain object to be persisted to Meilisearch.
 *
 * @since 1.0.0
 * @auther Junghoon Ban
 */

@Persistent
@Inherited
@Retention(RetentionPolicy.RUNTIME)
@Target({ElementType.TYPE})
public @interface Document {
  String indexUid();
}
```