### PR TITLE
chore: set default value for user agents

### DIFF
--- a/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
+++ b/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
@@ -40,10 +40,10 @@
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:attribute>
-                    <xsd:attribute name="client-agents" type="xsd:string">
+                    <xsd:attribute name="client-agents" type="xsd:string" default="Meilisearch Java (v0.11.1), Spring Data Meilisearch (v1.0.0)">
                         <xsd:annotation>
                             <xsd:documentation>
-                                <![CDATA[The comma delimited string array of client agents]]>
+                                <![CDATA[The comma delimited string array of client agents. The default is package name and version.]]>
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:attribute>

--- a/src/test/resources/io/vanslog/spring/data/meilisearch/config/namespace.xml
+++ b/src/test/resources/io/vanslog/spring/data/meilisearch/config/namespace.xml
@@ -6,5 +6,5 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
   <meilisearch:meilisearch-client id="meilisearchClient"
-    client-agents="Spring-Data-Meilisearch(v1.0.0), Meilisearch-Java(v0.11.1), Java(v17)"/>
+    client-agents="Meilisearch Java (v0.11.1), Spring Data Meilisearch (v1.0.0), Java (17)"/>
 </beans>


### PR DESCRIPTION
The `User-Agent` header is used to indicate the user agent that made the API call.
The [guideline](https://github.com/meilisearch/integration-guides/issues/150) is to represent the official SDK in the following format.

```
User-Agent: Meilisearch <language> (<version>)
```

Therefore, the default User-Agent for our project is set as follows.

```
User-Agent: Meilisearch Java (v0.11.1); Spring Data Meilisearch (v1.0.0)
```

If you want to override the default, see `namespace.xml` in test resource.

```xml
<meilisearch:meilisearch-client id="meilisearchClient"
     client-agents="Meilisearch Java (v0.11.1), Spring Data Meilisearch (v1.0.0), Java (17)"/>
```

For example, if you wanted to specify Java, you could write something like this