### PR TITLE
chore: declare values for json handler

### DIFF
--- a/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
+++ b/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
@@ -33,12 +33,30 @@
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:attribute>
-                    <xsd:attribute name="json-handler" type="xsd:string" default="GSON">
+                    <xsd:attribute name="json-handler" default="GSON">
                         <xsd:annotation>
                             <xsd:documentation>
                                 <![CDATA[The enum value of java: io.vanslog.spring.data.meilisearch.config.JsonHandlerBuilder. The default is GSON.]]>
                             </xsd:documentation>
                         </xsd:annotation>
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:enumeration value="GSON">
+                                    <xsd:annotation>
+                                        <xsd:documentation>
+                                            <![CDATA[Use GSON as the JSON handler.]]>
+                                        </xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:enumeration>
+                                <xsd:enumeration value="JACKSON">
+                                    <xsd:annotation>
+                                        <xsd:documentation>
+                                            <![CDATA[Use JACKSON as the JSON handler.]]>
+                                        </xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:enumeration>
+                            </xsd:restriction>
+                        </xsd:simpleType>
                     </xsd:attribute>
                     <xsd:attribute name="client-agents" type="xsd:string" default="Meilisearch Java (v0.11.1), Spring Data Meilisearch (v1.0.0)">
                         <xsd:annotation>


### PR DESCRIPTION
Provide `GSON` and `JACKSON` entries in the xml settings.

<img width="816" alt="스크린샷 2023-07-05 오후 8 09 00" src="https://github.com/junghoon-vans/spring-data-meilisearch/assets/44942700/04d89696-b76f-43ae-82e4-423b046b7137">

This feature allows users to customize which options are recommended.

