### PR TITLE
feat: implement meilisearch converter

### DIFF
--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverter.java
@@ -1,0 +1,49 @@
+package io.vanslog.spring.data.meilisearch.core.convert;
+
+import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentEntity;
+import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentProperty;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.util.Assert;
+
+/**
+ * MappingMeilisearchConverter
+ *
+ * @since 1.0.0
+ * @author Junghoon Ban
+ */
+public class MappingMeilisearchConverter implements MeilisearchConverter, ApplicationContextAware {
+
+  private final MappingContext<? extends MeilisearchPersistentEntity<?>, MeilisearchPersistentProperty> mappingContext;
+  private final GenericConversionService conversionService;
+
+  @SuppressWarnings("unused, FieldCanBeLocal")
+  private ApplicationContext applicationContext;
+
+  public MappingMeilisearchConverter(
+      MappingContext<? extends MeilisearchPersistentEntity<?>, MeilisearchPersistentProperty> mappingContext) {
+    Assert.notNull(mappingContext, "MappingContext must not be null!");
+    this.mappingContext = mappingContext;
+    this.conversionService = new DefaultConversionService();
+  }
+
+  @Override
+  public MappingContext<? extends MeilisearchPersistentEntity<?>, MeilisearchPersistentProperty> getMappingContext() {
+    return mappingContext;
+  }
+
+  @Override
+  public ConversionService getConversionService() {
+    return this.conversionService;
+  }
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    this.applicationContext = applicationContext;
+  }
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MeilisearchConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MeilisearchConverter.java
@@ -1,0 +1,30 @@
+package io.vanslog.spring.data.meilisearch.core.convert;
+
+import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentEntity;
+import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentProperty;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.data.mapping.context.MappingContext;
+
+/**
+ * Meilisearch converter aware of {@link MappingContext}.
+ *
+ * @since 1.0.0
+ * @see MappingContext
+ * @author Junghoon Ban
+ */
+public interface MeilisearchConverter {
+
+	/**
+	 * Returns the {@link MappingContext} used by the converter.
+	 *
+	 * @return never {@literal null}.
+	 */
+	MappingContext<? extends MeilisearchPersistentEntity<?>, MeilisearchPersistentProperty> getMappingContext();
+
+	/**
+	 * Returns the {@link ConversionService} used by the converter.
+	 *
+	 * @return never {@literal null}.
+	 */
+	ConversionService getConversionService();
+}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverterTest.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverterTest.java
@@ -1,0 +1,32 @@
+package io.vanslog.spring.data.meilisearch.core.convert;
+
+import io.vanslog.spring.data.meilisearch.core.mapping.SimpleMeilisearchMappingContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link MappingMeilisearchConverter}.
+ *
+ * @author Junghoon Ban
+ */
+class MappingMeilisearchConverterTest {
+
+  private MappingMeilisearchConverter converter;
+
+  @BeforeEach
+  void setUp() {
+    converter = new MappingMeilisearchConverter(new SimpleMeilisearchMappingContext());
+  }
+
+  @Test
+  void shouldReturnMappingContext() {
+    assertThat(converter.getMappingContext()).isNotNull();
+  }
+
+  @Test
+  void shouldReturnConversionService() {
+    assertThat(converter.getConversionService()).isNotNull();
+  }
+}


### PR DESCRIPTION
Description
---

The [convert](https://docs.spring.io/spring-framework/reference/core/validation/convert.html) are a feature provided by Spring Framework for generalized type conversion. `Meilisearch Converter` provides the necessary properties for type conversion. 