### PR TITLE
test: implement junit-jupiter extension for integration test

### DIFF
--- a/TESTING.adoc
+++ b/TESTING.adoc
@@ -1,0 +1,32 @@
+= Testing
+
+== Run the tests
+
+[source,bash]
+----
+mvn test
+----
+
+== Create integration test
+
+To create an integration test, you need to add the following annotation to your test class:
+
+[source,java]
+----
+@MeilisearchTest
+@ContextConfiguration(classes = {MeilisearchTestConfiguration.class})
+public class MeilisearchTest {
+
+    @Autowired
+    private MeilisearchClient client;
+
+    @Test
+    public void test() {
+        // ...
+    }
+}
+----
+
+The `MeilisearchTest` annotation means that the test is run in integration with Meilisearch.
+This code makes it easy to run the container.
+`MeilisearchTestConfiguration` is a configuration class for providing a `Client` associated with a container run by MeilisearchTest.

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
             <version>${assertj}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.vanslog</groupId>
+            <artifactId>testcontainers-meilisearch</artifactId>
+            <version>1.0.1</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchConnection.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchConnection.java
@@ -11,52 +11,60 @@ import org.testcontainers.utility.DockerImageName;
  *
  * @author Junghoon Ban
  */
-public class MeilisearchConnection implements ExtensionContext.Store.CloseableResource {
+public class MeilisearchConnection
+        implements ExtensionContext.Store.CloseableResource {
 
-  private static final Log LOGGER = LogFactory.getLog(MeilisearchConnection.class);
-  private static final String TESTCONTAINERS_IMAGE_NAME = "getmeili/meilisearch";
-  private static final String TESTCONTAINERS_IMAGE_VERSION = "v1.2.0";
-  private static final int MEILISEARCH_DEFAULT_PORT = 7700;
-  private static final String MEILISEARCH_DEFAULT_MASTER_KEY = "masterKey";
-  private static final ThreadLocal<MeilisearchConnectionInfo> meilisearchConnectionInfoThreadLocal = new ThreadLocal<>();
-  private final MeilisearchConnectionInfo meilisearchConnectionInfo;
+    private static final Log LOGGER =
+            LogFactory.getLog(MeilisearchConnection.class);
+    private static final String TESTCONTAINERS_IMAGE_NAME =
+            "getmeili/meilisearch";
+    private static final String TESTCONTAINERS_IMAGE_VERSION = "v1.2.0";
+    private static final int MEILISEARCH_DEFAULT_PORT = 7700;
+    private static final String MEILISEARCH_DEFAULT_MASTER_KEY = "masterKey";
+    private static final ThreadLocal<MeilisearchConnectionInfo>
+            meilisearchConnectionInfoThreadLocal = new ThreadLocal<>();
+    private final MeilisearchConnectionInfo meilisearchConnectionInfo;
 
-  public MeilisearchConnection() {
-    meilisearchConnectionInfo = createConnectionInfo();
-    if (meilisearchConnectionInfo != null) {
-      meilisearchConnectionInfoThreadLocal.set(meilisearchConnectionInfo);
+    public MeilisearchConnection() {
+        meilisearchConnectionInfo = createConnectionInfo();
+        if (meilisearchConnectionInfo != null) {
+            meilisearchConnectionInfoThreadLocal.set(meilisearchConnectionInfo);
+        }
     }
-  }
 
-  public static MeilisearchConnectionInfo meilisearchConnectionInfo() {
-    return meilisearchConnectionInfoThreadLocal.get();
-  }
-
-  public MeilisearchConnectionInfo getMeilisearchConnectionInfo() {
-    return meilisearchConnectionInfo;
-  }
-
-  public MeilisearchConnectionInfo createConnectionInfo() {
-    DockerImageName dockerImageName = DockerImageName.parse(TESTCONTAINERS_IMAGE_NAME)
-        .withTag(TESTCONTAINERS_IMAGE_VERSION);
-    MeilisearchContainer meilisearchContainer = new MeilisearchContainer(dockerImageName)
-        .withMasterKey(MEILISEARCH_DEFAULT_MASTER_KEY);
-    meilisearchContainer.start();
-
-    return MeilisearchConnectionInfo.builder()
-        .host(meilisearchContainer.getHost())
-        .port(meilisearchContainer.getMappedPort(MEILISEARCH_DEFAULT_PORT))
-        .masterKey(MEILISEARCH_DEFAULT_MASTER_KEY)
-        .meilisearchContainer(meilisearchContainer)
-        .build();
-  }
-
-  @Override
-  public void close() {
-    if (meilisearchConnectionInfo != null && meilisearchConnectionInfo.getMeilisearchContainer() != null) {
-      LOGGER.debug("stopping MeilisearchConnection");
-      meilisearchConnectionInfo.getMeilisearchContainer().stop();
+    public static MeilisearchConnectionInfo meilisearchConnectionInfo() {
+        return meilisearchConnectionInfoThreadLocal.get();
     }
-    LOGGER.debug("closed MeilisearchConnection");
-  }
+
+    public MeilisearchConnectionInfo getMeilisearchConnectionInfo() {
+        return meilisearchConnectionInfo;
+    }
+
+    public MeilisearchConnectionInfo createConnectionInfo() {
+        DockerImageName dockerImageName =
+                DockerImageName.parse(TESTCONTAINERS_IMAGE_NAME)
+                        .withTag(TESTCONTAINERS_IMAGE_VERSION);
+        MeilisearchContainer meilisearchContainer =
+                new MeilisearchContainer(dockerImageName)
+                        .withMasterKey(MEILISEARCH_DEFAULT_MASTER_KEY);
+        meilisearchContainer.start();
+
+        return MeilisearchConnectionInfo.builder()
+                .host(meilisearchContainer.getHost())
+                .port(meilisearchContainer.getMappedPort(
+                        MEILISEARCH_DEFAULT_PORT))
+                .masterKey(MEILISEARCH_DEFAULT_MASTER_KEY)
+                .meilisearchContainer(meilisearchContainer)
+                .build();
+    }
+
+    @Override
+    public void close() {
+        if (meilisearchConnectionInfo != null &&
+                meilisearchConnectionInfo.getMeilisearchContainer() != null) {
+            LOGGER.debug("stopping MeilisearchConnection");
+            meilisearchConnectionInfo.getMeilisearchContainer().stop();
+        }
+        LOGGER.debug("closed MeilisearchConnection");
+    }
 }

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchConnection.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchConnection.java
@@ -1,0 +1,54 @@
+package io.vanslog.spring.data.meilisearch.junit.jupiter;
+
+import io.vanslog.testcontainers.meilisearch.MeilisearchContainer;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * This class manages the connection to Meilisearch Instance.
+ *
+ * @author Junghoon Ban
+ */
+public class MeilisearchConnection implements ExtensionContext.Store.CloseableResource {
+
+  private static final Log LOGGER = LogFactory.getLog(MeilisearchConnection.class);
+  private static final String TESTCONTAINERS_IMAGE_NAME = "getmeili/meilisearch";
+  private static final String TESTCONTAINERS_IMAGE_VERSION = "v1.2.0";
+  private static final int MEILISEARCH_DEFAULT_PORT = 7700;
+  private static final String MEILISEARCH_DEFAULT_MASTER_KEY = "masterKey";
+  private final MeilisearchConnectionInfo meilisearchConnectionInfo;
+
+  public MeilisearchConnection() {
+    meilisearchConnectionInfo = createConnectionInfo();
+  }
+
+  public MeilisearchConnectionInfo getMeilisearchConnectionInfo() {
+    return meilisearchConnectionInfo;
+  }
+
+  public MeilisearchConnectionInfo createConnectionInfo() {
+    DockerImageName dockerImageName = DockerImageName.parse(TESTCONTAINERS_IMAGE_NAME)
+        .withTag(TESTCONTAINERS_IMAGE_VERSION);
+    MeilisearchContainer meilisearchContainer = new MeilisearchContainer(dockerImageName)
+        .withMasterKey(MEILISEARCH_DEFAULT_MASTER_KEY);
+    meilisearchContainer.start();
+
+    return MeilisearchConnectionInfo.builder()
+        .host(meilisearchContainer.getHost())
+        .port(meilisearchContainer.getMappedPort(MEILISEARCH_DEFAULT_PORT))
+        .masterKey(MEILISEARCH_DEFAULT_MASTER_KEY)
+        .meilisearchContainer(meilisearchContainer)
+        .build();
+  }
+
+  @Override
+  public void close() {
+    if (meilisearchConnectionInfo != null && meilisearchConnectionInfo.getMeilisearchContainer() != null) {
+      LOGGER.debug("stopping MeilisearchConnection");
+      meilisearchConnectionInfo.getMeilisearchContainer().stop();
+    }
+    LOGGER.debug("closed MeilisearchConnection");
+  }
+}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchConnection.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchConnection.java
@@ -18,10 +18,18 @@ public class MeilisearchConnection implements ExtensionContext.Store.CloseableRe
   private static final String TESTCONTAINERS_IMAGE_VERSION = "v1.2.0";
   private static final int MEILISEARCH_DEFAULT_PORT = 7700;
   private static final String MEILISEARCH_DEFAULT_MASTER_KEY = "masterKey";
+  private static final ThreadLocal<MeilisearchConnectionInfo> meilisearchConnectionInfoThreadLocal = new ThreadLocal<>();
   private final MeilisearchConnectionInfo meilisearchConnectionInfo;
 
   public MeilisearchConnection() {
     meilisearchConnectionInfo = createConnectionInfo();
+    if (meilisearchConnectionInfo != null) {
+      meilisearchConnectionInfoThreadLocal.set(meilisearchConnectionInfo);
+    }
+  }
+
+  public static MeilisearchConnectionInfo meilisearchConnectionInfo() {
+    return meilisearchConnectionInfoThreadLocal.get();
   }
 
   public MeilisearchConnectionInfo getMeilisearchConnectionInfo() {

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchConnectionInfo.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchConnectionInfo.java
@@ -5,83 +5,85 @@ import io.vanslog.testcontainers.meilisearch.MeilisearchContainer;
 /**
  * This class is used to store the connection information for Meilisearch.
  *
- * @see MeilisearchConnection
  * @author Junghoon Ban
+ * @see MeilisearchConnection
  */
 public class MeilisearchConnectionInfo {
 
-  private final String host;
-  private final int port;
-  private final String masterKey;
-  private final MeilisearchContainer meilisearchContainer;
+    private final String host;
+    private final int port;
+    private final String masterKey;
+    private final MeilisearchContainer meilisearchContainer;
 
-  private MeilisearchConnectionInfo(String host, int port, String masterKey,
-      MeilisearchContainer meilisearchContainer) {
-    this.host = host;
-    this.port = port;
-    this.masterKey = masterKey;
-    this.meilisearchContainer = meilisearchContainer;
-  }
-
-  @Override
-  public String toString() {
-    return "MeilisearchConnectionInfo{" +
-        "host='" + host + '\'' +
-        ", port=" + port +
-        ", masterKey='" + masterKey + '\'' +
-        ", meilisearchContainer=" + meilisearchContainer +
-        '}';
-  }
-
-  public static Builder builder() {
-    return new Builder();
-  }
-
-  public String getHost() {
-    return host;
-  }
-
-  public int getPort() {
-    return port;
-  }
-
-  public String getMasterKey() {
-    return masterKey;
-  }
-
-  public MeilisearchContainer getMeilisearchContainer() {
-    return meilisearchContainer;
-  }
-
-  public static class Builder {
-
-    private String host;
-    private int port;
-    private String masterKey;
-    private MeilisearchContainer meilisearchContainer;
-
-    public Builder host(String host) {
-      this.host = host;
-      return this;
+    private MeilisearchConnectionInfo(String host, int port, String masterKey,
+                                      MeilisearchContainer meilisearchContainer) {
+        this.host = host;
+        this.port = port;
+        this.masterKey = masterKey;
+        this.meilisearchContainer = meilisearchContainer;
     }
 
-    public Builder port(int port) {
-      this.port = port;
-      return this;
+    @Override
+    public String toString() {
+        return "MeilisearchConnectionInfo{" +
+                "host='" + host + '\'' +
+                ", port=" + port +
+                ", masterKey='" + masterKey + '\'' +
+                ", meilisearchContainer=" + meilisearchContainer +
+                '}';
     }
 
-    public Builder masterKey(String masterKey) {
-      this.masterKey = masterKey;
-      return this;
+    public static Builder builder() {
+        return new Builder();
     }
 
-    public Builder meilisearchContainer(MeilisearchContainer meilisearchContainer) {
-      this.meilisearchContainer = meilisearchContainer;
-      return this;
+    public String getHost() {
+        return host;
     }
 
-    public MeilisearchConnectionInfo build() {
-      return new MeilisearchConnectionInfo(host, port, masterKey, meilisearchContainer);
+    public int getPort() {
+        return port;
     }
-  }
+
+    public String getMasterKey() {
+        return masterKey;
+    }
+
+    public MeilisearchContainer getMeilisearchContainer() {
+        return meilisearchContainer;
+    }
+
+    public static class Builder {
+
+        private String host;
+        private int port;
+        private String masterKey;
+        private MeilisearchContainer meilisearchContainer;
+
+        public Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public Builder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        public Builder masterKey(String masterKey) {
+            this.masterKey = masterKey;
+            return this;
+        }
+
+        public Builder meilisearchContainer(
+                MeilisearchContainer meilisearchContainer) {
+            this.meilisearchContainer = meilisearchContainer;
+            return this;
+        }
+
+        public MeilisearchConnectionInfo build() {
+            return new MeilisearchConnectionInfo(host, port, masterKey,
+                    meilisearchContainer);
+        }
+    }
 }

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchConnectionInfo.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchConnectionInfo.java
@@ -1,0 +1,87 @@
+package io.vanslog.spring.data.meilisearch.junit.jupiter;
+
+import io.vanslog.testcontainers.meilisearch.MeilisearchContainer;
+
+/**
+ * This class is used to store the connection information for Meilisearch.
+ *
+ * @see MeilisearchConnection
+ * @author Junghoon Ban
+ */
+public class MeilisearchConnectionInfo {
+
+  private final String host;
+  private final int port;
+  private final String masterKey;
+  private final MeilisearchContainer meilisearchContainer;
+
+  private MeilisearchConnectionInfo(String host, int port, String masterKey,
+      MeilisearchContainer meilisearchContainer) {
+    this.host = host;
+    this.port = port;
+    this.masterKey = masterKey;
+    this.meilisearchContainer = meilisearchContainer;
+  }
+
+  @Override
+  public String toString() {
+    return "MeilisearchConnectionInfo{" +
+        "host='" + host + '\'' +
+        ", port=" + port +
+        ", masterKey='" + masterKey + '\'' +
+        ", meilisearchContainer=" + meilisearchContainer +
+        '}';
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public String getMasterKey() {
+    return masterKey;
+  }
+
+  public MeilisearchContainer getMeilisearchContainer() {
+    return meilisearchContainer;
+  }
+
+  public static class Builder {
+
+    private String host;
+    private int port;
+    private String masterKey;
+    private MeilisearchContainer meilisearchContainer;
+
+    public Builder host(String host) {
+      this.host = host;
+      return this;
+    }
+
+    public Builder port(int port) {
+      this.port = port;
+      return this;
+    }
+
+    public Builder masterKey(String masterKey) {
+      this.masterKey = masterKey;
+      return this;
+    }
+
+    public Builder meilisearchContainer(MeilisearchContainer meilisearchContainer) {
+      this.meilisearchContainer = meilisearchContainer;
+      return this;
+    }
+
+    public MeilisearchConnectionInfo build() {
+      return new MeilisearchConnectionInfo(host, port, masterKey, meilisearchContainer);
+    }
+  }
+}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchExtension.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchExtension.java
@@ -1,0 +1,17 @@
+package io.vanslog.spring.data.meilisearch.junit.jupiter;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Extension for JUnit Jupiter to provide a Meilisearch connection.
+ *
+ * @author Junghoon Ban
+ */
+public class MeilisearchExtension implements BeforeAllCallback{
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    new MeilisearchConnection();
+  }
+}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchExtension.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchExtension.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  *
  * @author Junghoon Ban
  */
-public class MeilisearchExtension implements BeforeAllCallback{
+public class MeilisearchExtension implements BeforeAllCallback {
 
-  @Override
-  public void beforeAll(ExtensionContext context) {
-    new MeilisearchConnection();
-  }
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        new MeilisearchConnection();
+    }
 }

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchExtension.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchExtension.java
@@ -1,5 +1,7 @@
 package io.vanslog.spring.data.meilisearch.junit.jupiter;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -10,8 +12,15 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  */
 public class MeilisearchExtension implements BeforeAllCallback {
 
+    private final Lock initLock = new ReentrantLock();
+
     @Override
     public void beforeAll(ExtensionContext context) {
-        new MeilisearchConnection();
+        initLock.lock();
+        try {
+            new MeilisearchConnection();
+        } finally {
+            initLock.unlock();
+        }
     }
 }

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchTest.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchTest.java
@@ -1,13 +1,14 @@
 package io.vanslog.spring.data.meilisearch.junit.jupiter;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Annotation to activate Meilisearch integration tests.

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchTest.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchTest.java
@@ -4,7 +4,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Annotation to activate Meilisearch integration tests.
@@ -14,5 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @ExtendWith(MeilisearchExtension.class)
+@ExtendWith(SpringExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public @interface MeilisearchTest {
 }

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchTest.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchTest.java
@@ -1,0 +1,18 @@
+package io.vanslog.spring.data.meilisearch.junit.jupiter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Annotation to activate Meilisearch integration tests.
+ *
+ * @author Junghoon Ban
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ExtendWith(MeilisearchExtension.class)
+public @interface MeilisearchTest {
+}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchTestConfiguration.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchTestConfiguration.java
@@ -1,0 +1,27 @@
+package io.vanslog.spring.data.meilisearch.junit.jupiter;
+
+import com.meilisearch.sdk.Config;
+import io.vanslog.spring.data.meilisearch.client.ClientConfiguration;
+import io.vanslog.spring.data.meilisearch.config.MeilisearchConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Custom Meilisearch configuration for integration tests.
+ */
+@Configuration
+public class MeilisearchTestConfiguration extends MeilisearchConfiguration {
+
+    private static final String HTTP = "http://";
+
+    private final MeilisearchConnectionInfo meilisearchConnectionInfo
+            = MeilisearchConnection.meilisearchConnectionInfo();
+
+    @Override
+    public Config clientConfiguration() {
+        return ClientConfiguration.builder()
+                .connectedTo(HTTP + meilisearchConnectionInfo.getHost() + ":" +
+                        meilisearchConnectionInfo.getPort())
+                .withApiKey(meilisearchConnectionInfo.getMasterKey())
+                .build();
+    }
+}


### PR DESCRIPTION
Related Issue
---

#16

Description
---

Provide extensions for integration testing with Meilisearch containers

```java
@MeilisearchTest
@ContextConfiguration(classes = {MeilisearchTestConfiguration.class})
class MeiliContainerTest {

    @Autowired
    Client client;
}
```

The `MeilisearchTest` annotation means that the test is run in integration with Meilisearch. This code makes it easy to run the container. `MeilisearchTestConfiguration` is a configuration class for providing a `Client` associated with a container run by MeilisearchTest.

