### PR TITLE
chore: set initial version to v0.1.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 ext {
-    projectVersion = '1.0.0-SNAPSHOT'
+    projectVersion = '0.1.0-SNAPSHOT'
 }
 
 group = 'io.vanslog'


### PR DESCRIPTION
## Description

Set the initial version of the project to `v0.1.0-SNAPSHOT`.