### PR TITLE
feat: support annotation based configuration

### DIFF
--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/ClientConfiguration.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/ClientConfiguration.java
@@ -1,0 +1,13 @@
+package io.vanslog.spring.data.meilisearch.client;
+
+import com.meilisearch.sdk.Config;
+
+/**
+ * Interface for Meilisearch {@link Config}.
+ */
+public interface ClientConfiguration {
+
+  static ClientConfigurationBuilder builder() {
+    return new ClientConfigurationBuilder();
+  }
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/ClientConfigurationBuilder.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/ClientConfigurationBuilder.java
@@ -1,0 +1,56 @@
+package io.vanslog.spring.data.meilisearch.client;
+
+import com.meilisearch.sdk.Config;
+import com.meilisearch.sdk.json.GsonJsonHandler;
+import com.meilisearch.sdk.json.JacksonJsonHandler;
+import com.meilisearch.sdk.json.JsonHandler;
+
+/**
+ * A builder for Meilisearch {@link Config}.
+ */
+public class ClientConfigurationBuilder {
+
+  private String hostUrl;
+  private String apiKey;
+  private JsonHandler jsonHandler;
+  private String[] clientAgents;
+
+  public ClientConfigurationBuilder() {
+    this.jsonHandler = new JacksonJsonHandler();
+    this.clientAgents = new String[0];
+  }
+
+  public ClientConfigurationBuilder connectedToLocalhost() {
+    this.hostUrl = "http://localhost:7700";
+    return this;
+  }
+
+  public ClientConfigurationBuilder connectedTo(String hostUrl) {
+    this.hostUrl = hostUrl;
+    return this;
+  }
+
+  public ClientConfigurationBuilder withApiKey(String apiKey) {
+    this.apiKey = apiKey;
+    return this;
+  }
+
+  public ClientConfigurationBuilder withJacksonJsonHandler() {
+    this.jsonHandler = new JacksonJsonHandler();
+    return this;
+  }
+
+  public ClientConfigurationBuilder withGsonJsonHandler() {
+    this.jsonHandler = new GsonJsonHandler();
+    return this;
+  }
+
+  public ClientConfigurationBuilder withClientAgents(String[] clientAgents) {
+    this.clientAgents = clientAgents;
+    return this;
+  }
+
+  public Config build() {
+    return new Config(this.hostUrl, this.apiKey, this.jsonHandler, this.clientAgents);
+  }
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfiguration.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfiguration.java
@@ -1,0 +1,22 @@
+package io.vanslog.spring.data.meilisearch.config;
+
+import com.meilisearch.sdk.Client;
+import com.meilisearch.sdk.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Base class for a @{@link org.springframework.context.annotation.Configuration} class to set up the Meilisearch
+ * connection using the Meilisearch Client.
+ */
+@Configuration(proxyBeanMethods = false)
+public abstract class MeilisearchConfiguration {
+
+  @Bean(name = "meilisearchClientConfiguration")
+  public abstract Config clientConfiguration();
+
+  @Bean(name = "meilisearchClient")
+  public Client meilisearchClient(Config clientConfiguration) {
+    return new Client(clientConfiguration);
+  }
+}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/client/ClientConfigurationTest.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/client/ClientConfigurationTest.java
@@ -1,0 +1,27 @@
+package io.vanslog.spring.data.meilisearch.client;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.meilisearch.sdk.Config;
+import com.meilisearch.sdk.json.GsonJsonHandler;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ClientConfiguration}.
+ */
+class ClientConfigurationTest {
+
+  @Test
+  void shouldBuildConfiguration() {
+    Config clientConfiguration = ClientConfiguration.builder()
+        .connectedToLocalhost()
+        .withApiKey("masterKey")
+        .withGsonJsonHandler()
+        .build();
+
+    assertThat(clientConfiguration.getHostUrl()).isEqualTo("http://localhost:7700");
+    assertThat(clientConfiguration.getApiKey()).isEqualTo("masterKey");
+    assertThat(clientConfiguration.getJsonHandler()).isInstanceOf(GsonJsonHandler.class);
+    assertThat(clientConfiguration.getHeaders().get("User-Agent")).contains("Meilisearch Java");
+  }
+}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfigurationTest.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfigurationTest.java
@@ -1,0 +1,38 @@
+package io.vanslog.spring.data.meilisearch.config;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.meilisearch.sdk.Client;
+import com.meilisearch.sdk.Config;
+import com.meilisearch.sdk.exceptions.MeilisearchException;
+import io.vanslog.spring.data.meilisearch.client.ClientConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+class MeilisearchConfigurationTest {
+
+  @Configuration
+  static class CustomConfiguration extends MeilisearchConfiguration {
+    @Override
+    public Config clientConfiguration() {
+      return ClientConfiguration.builder()
+          .connectedToLocalhost()
+          .withApiKey("masterKey")
+          .withGsonJsonHandler()
+          .build();
+    }
+  }
+
+  @Autowired private Client client;
+
+  @Test
+  void shouldCreateClient() throws MeilisearchException {
+    assertThat(client).isNotNull();
+  }
+}


### PR DESCRIPTION
## Related Issue

#22 

## Description

Now, you can set up the client with Java `annotation-based` configuration.
Here's a simple example code

```java
@Configuration
  static class CustomConfiguration extends MeilisearchConfiguration {
    @Override
    public Config clientConfiguration() {
      return ClientConfiguration.builder()
          .connectedToLocalhost()
          .withApiKey("masterKey")
          .withGsonJsonHandler()
          .build();
    }
  }
```
