### PR TITLE
Fix/duplicated client agents

### DIFF
--- a/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
+++ b/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
@@ -58,7 +58,7 @@
                             </xsd:restriction>
                         </xsd:simpleType>
                     </xsd:attribute>
-                    <xsd:attribute name="client-agents" type="xsd:string" default="Meilisearch Java (v0.11.1), Spring Data Meilisearch (v1.0.0)">
+                    <xsd:attribute name="client-agents" type="xsd:string" default="Spring Data Meilisearch (v1.0.0)">
                         <xsd:annotation>
                             <xsd:documentation>
                                 <![CDATA[The comma delimited string array of client agents. The default is package name and version.]]>

--- a/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
+++ b/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
@@ -58,7 +58,7 @@
                             </xsd:restriction>
                         </xsd:simpleType>
                     </xsd:attribute>
-                    <xsd:attribute name="client-agents" type="xsd:string" default="Spring Data Meilisearch (v1.0.0)">
+                    <xsd:attribute name="client-agents" type="xsd:string" default="Spring Data Meilisearch (v0.1.0)">
                         <xsd:annotation>
                             <xsd:documentation>
                                 <![CDATA[The comma delimited string array of client agents. The default is package name and version.]]>


### PR DESCRIPTION
## Description

The meilisearch-java sdk that is used within the project passes the client-agents information along by default, so there is no need to set that information redundantly.
