### PR TITLE
docs(javadoc): remove since tag

### DIFF
--- a/src/main/java/io/vanslog/spring/data/meilisearch/annotations/Document.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/annotations/Document.java
@@ -12,7 +12,6 @@ import java.lang.annotation.Target;
  * Identifies a domain object to be persisted to Meilisearch.
  *
  * @author Junghoon Ban
- * @since 1.0.0
  */
 
 @Persistent

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/MeilisearchClientFactoryBean.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/MeilisearchClientFactoryBean.java
@@ -17,7 +17,6 @@ import org.springframework.lang.Nullable;
  *
  * @author Junghoon Ban
  * @see Client
- * @since 1.0.0
  */
 public final class MeilisearchClientFactoryBean
         implements FactoryBean<Client>, InitializingBean, DisposableBean {

--- a/src/main/java/io/vanslog/spring/data/meilisearch/config/JsonHandlerBuilder.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/config/JsonHandlerBuilder.java
@@ -11,7 +11,6 @@ import com.meilisearch.sdk.json.JsonHandler;
  * @see JsonHandler
  * @see GsonJsonHandler
  * @see JacksonJsonHandler
- * @since 1.0.0
  */
 public enum JsonHandlerBuilder {
     GSON {

--- a/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchClientBeanDefinitionParser.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchClientBeanDefinitionParser.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
  * by setting the host URL, API key, JSON handler, and client agents.
  *
  * @author Junghoon Ban
- * @since 1.0.0
  */
 
 public class MeilisearchClientBeanDefinitionParser

--- a/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchNamespaceHandler.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchNamespaceHandler.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
  * in the XML configuration file.
  *
  * @author Junghoon Ban
- * @since 1.0.0
  */
 public class MeilisearchNamespaceHandler extends NamespaceHandlerSupport {
 

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverter.java
@@ -16,7 +16,6 @@ import org.springframework.util.Assert;
  * {@link MeilisearchConverter} Implementation based on {@link MappingContext}.
  *
  * @author Junghoon Ban
- * @since 1.0.0
  */
 public class MappingMeilisearchConverter
         implements MeilisearchConverter, ApplicationContextAware {

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MeilisearchConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MeilisearchConverter.java
@@ -10,7 +10,6 @@ import org.springframework.data.mapping.context.MappingContext;
  *
  * @author Junghoon Ban
  * @see MappingContext
- * @since 1.0.0
  */
 public interface MeilisearchConverter {
 

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/mapping/MeilisearchPersistentEntity.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/mapping/MeilisearchPersistentEntity.java
@@ -7,7 +7,6 @@ import org.springframework.data.mapping.PersistentEntity;
  *
  * @param <T>
  * @author Junghoon Ban
- * @since 1.0.0
  */
 public interface MeilisearchPersistentEntity<T>
         extends PersistentEntity<T, MeilisearchPersistentProperty> {

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/mapping/MeilisearchPersistentProperty.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/mapping/MeilisearchPersistentProperty.java
@@ -7,7 +7,6 @@ import org.springframework.data.mapping.PersistentProperty;
  * Meilisearch specific {@link PersistentProperty} abstraction.
  *
  * @author Junghoon Ban
- * @since 1.0.0
  */
 public interface MeilisearchPersistentProperty
         extends PersistentProperty<MeilisearchPersistentProperty> {

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/mapping/SimpleMeilisearchMappingContext.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/mapping/SimpleMeilisearchMappingContext.java
@@ -9,7 +9,6 @@ import org.springframework.data.util.TypeInformation;
  * Meilisearch specific {@link AbstractMappingContext} implementation.
  *
  * @author Junghoon Ban
- * @since 1.0.0
  */
 public class SimpleMeilisearchMappingContext extends
         AbstractMappingContext<SimpleMeilisearchPersistentEntity<?>,

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/mapping/SimpleMeilisearchPersistentEntity.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/mapping/SimpleMeilisearchPersistentEntity.java
@@ -17,7 +17,6 @@ import org.springframework.util.Assert;
  *
  * @param <T>
  * @author Junghoon Ban
- * @since 1.0.0
  */
 public class SimpleMeilisearchPersistentEntity<T>
         extends BasicPersistentEntity<T, MeilisearchPersistentProperty>

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/mapping/SimpleMeilisearchPersistentProperty.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/mapping/SimpleMeilisearchPersistentProperty.java
@@ -14,7 +14,6 @@ import java.util.List;
  * Meilisearch specific {@link PersistentEntity} implementation holding.
  *
  * @author Junghoon Ban
- * @since 1.0.0
  */
 public class SimpleMeilisearchPersistentProperty
         extends AnnotationBasedPersistentProperty<MeilisearchPersistentProperty>

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/support/DefaultEntityMapper.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/support/DefaultEntityMapper.java
@@ -12,7 +12,6 @@ import java.io.IOException;
  * @author Junghoon Ban
  * @see EntityMapper
  * @see ObjectMapper
- * @since 1.0.0
  */
 public class DefaultEntityMapper implements EntityMapper {
 

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/support/EntityMapper.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/support/EntityMapper.java
@@ -6,7 +6,6 @@ import java.io.IOException;
  * Interface to map entity to JSON and vice versa.
  *
  * @author Junghoon Ban
- * @since 1.0.0
  */
 public interface EntityMapper {
 


### PR DESCRIPTION
## Description

This library is still in an unstable stage, and changes to the API implementation can be frequent.
Therefore, since version 1.0, `@since`tag will be provided.