### PR TITLE
refactor: drop default value for meilisearch client

### DIFF
--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/ClientConfigurationBuilder.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/ClientConfigurationBuilder.java
@@ -5,6 +5,7 @@ import com.meilisearch.sdk.json.GsonJsonHandler;
 import com.meilisearch.sdk.json.JacksonJsonHandler;
 import com.meilisearch.sdk.json.JsonHandler;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * A builder for Meilisearch {@link Config}.
@@ -88,6 +89,7 @@ public class ClientConfigurationBuilder {
      * @return {@link Config}
      */
     public Config build() {
+        Assert.notNull(this.apiKey, "API Key must not be null");
         return new Config(this.hostUrl, this.apiKey, this.jsonHandler,
                 this.clientAgents);
     }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchClientBeanDefinitionParser.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchClientBeanDefinitionParser.java
@@ -33,6 +33,10 @@ public class MeilisearchClientBeanDefinitionParser
 
     private void setLocalSettings(Element element,
                                   BeanDefinitionBuilder builder) {
+
+        Assert.hasText(element.getAttribute("api-key"),
+                "The attribute 'api-key' is required.");
+
         builder.addPropertyValue("hostUrl", element.getAttribute("host-url"));
         builder.addPropertyValue("apiKey", element.getAttribute("api-key"));
         builder.addPropertyValue("clientAgents",

--- a/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
+++ b/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
@@ -26,7 +26,7 @@
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:attribute>
-                    <xsd:attribute name="api-key" type="xsd:string" default="masterKey">
+                    <xsd:attribute name="api-key" type="xsd:string">
                         <xsd:annotation>
                             <xsd:documentation>
                                 <![CDATA[The API key of the Meilisearch server.]]>

--- a/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
+++ b/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
@@ -58,10 +58,10 @@
                             </xsd:restriction>
                         </xsd:simpleType>
                     </xsd:attribute>
-                    <xsd:attribute name="client-agents" type="xsd:string" default="Spring Data Meilisearch (v0.1.0)">
+                    <xsd:attribute name="client-agents" type="xsd:string">
                         <xsd:annotation>
                             <xsd:documentation>
-                                <![CDATA[The comma delimited string array of client agents. The default is package name and version.]]>
+                                <![CDATA[The comma delimited string array of client agents.]]>
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:attribute>

--- a/src/test/resources/io/vanslog/spring/data/meilisearch/config/namespace.xml
+++ b/src/test/resources/io/vanslog/spring/data/meilisearch/config/namespace.xml
@@ -7,6 +7,5 @@
        http://www.vanslog.io/spring/data/meilisearch
        http://www.vanslog.io/spring/data/meilisearch/spring-meilisearch-1.0.xsd">
 
-    <meilisearch:meilisearch-client id="meilisearchClient"
-                                    client-agents="Meilisearch Java (v0.11.1), Spring Data Meilisearch (v1.0.0), Java (17)"/>
+    <meilisearch:meilisearch-client id="meilisearchClient" api-key="masterKey"/>
 </beans>


### PR DESCRIPTION
## Description

The default value of `api-key` will no longer be provided,
because the key of a Meilisearch instance is determined by the user.

At the same time, the default value of `client-agents` on the client is also broken.
Users can customize them as needed.