### PR TITLE
refactor: make meilisearch client a wrapper class

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ This library support using Java based `@Configuration` or XML Namespace for conf
 public class CustomConfiguration extends MeilisearchConfiguration {
 
   @Override
-  public Config clientConfiguration() {
+  public ClientConfiguration clientConfiguration() {
     return ClientConfiguration.builder()
         .connectedToLocalhost()
         .withApiKey("masterKey")

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/ClientConfiguration.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/ClientConfiguration.java
@@ -1,7 +1,10 @@
 package io.vanslog.spring.data.meilisearch.client;
 
+import com.meilisearch.sdk.Config;
+import com.meilisearch.sdk.json.JsonHandler;
+
 /**
- * Interface for Meilisearch {@link com.meilisearch.sdk.Config}.
+ * Interface for Meilisearch Configuration.
  *
  * @author Junghoon Ban
  */
@@ -9,9 +12,45 @@ public interface ClientConfiguration {
 
     /**
      * Create a new {@link ClientConfigurationBuilder}.
+     *
      * @return ClientConfigurationBuilder
      */
     static ClientConfigurationBuilder builder() {
         return new ClientConfigurationBuilder();
     }
+
+    /**
+     * Get the hostUrl.
+     *
+     * @return hostUrl
+     */
+    String getHostUrl();
+
+    /**
+     * Get the apiKey.
+     *
+     * @return apiKey
+     */
+    String getApiKey();
+
+    /**
+     * Get the jsonHandler.
+     *
+     * @return jsonHandler
+     */
+    JsonHandler getJsonHandler();
+
+    /**
+     * Get the clientAgents.
+     *
+     * @return clientAgents
+     */
+    String[] getClientAgents();
+
+    /**
+     * Get the config.
+     *
+     * @return config
+     */
+    Config getConfig();
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/ClientConfigurationBuilder.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/ClientConfigurationBuilder.java
@@ -1,6 +1,5 @@
 package io.vanslog.spring.data.meilisearch.client;
 
-import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.json.GsonJsonHandler;
 import com.meilisearch.sdk.json.JacksonJsonHandler;
 import com.meilisearch.sdk.json.JsonHandler;
@@ -8,14 +7,16 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
- * A builder for Meilisearch {@link Config}.
+ * A builder for Meilisearch {@link ClientConfiguration}.
  *
  * @author Junghoon Ban
  */
 public class ClientConfigurationBuilder {
 
-    @Nullable private String hostUrl;
-    @Nullable private String apiKey;
+    @Nullable
+    private String hostUrl;
+    @Nullable
+    private String apiKey;
     private JsonHandler jsonHandler;
     private String[] clientAgents;
 
@@ -29,6 +30,7 @@ public class ClientConfigurationBuilder {
 
     /**
      * Connect to localhost:7700.
+     *
      * @return {@link ClientConfigurationBuilder}
      */
     public ClientConfigurationBuilder connectedToLocalhost() {
@@ -38,6 +40,7 @@ public class ClientConfigurationBuilder {
 
     /**
      * Connect to the given hostUrl.
+     *
      * @param hostUrl the hostUrl to connect to
      * @return {@link ClientConfigurationBuilder}
      */
@@ -48,6 +51,7 @@ public class ClientConfigurationBuilder {
 
     /**
      * Configure API key to access Meilisearch instance.
+     *
      * @param apiKey the apiKey to use
      * @return {@link ClientConfigurationBuilder}
      */
@@ -58,6 +62,7 @@ public class ClientConfigurationBuilder {
 
     /**
      * Configure json handler as {@link JacksonJsonHandler}.
+     *
      * @return {@link ClientConfigurationBuilder}
      */
     public ClientConfigurationBuilder withJacksonJsonHandler() {
@@ -67,6 +72,7 @@ public class ClientConfigurationBuilder {
 
     /**
      * Configure json handler as {@link GsonJsonHandler}.
+     *
      * @return {@link ClientConfigurationBuilder}
      */
     public ClientConfigurationBuilder withGsonJsonHandler() {
@@ -76,6 +82,7 @@ public class ClientConfigurationBuilder {
 
     /**
      * Configure client agents that will be sent with User-Agent header.
+     *
      * @param clientAgents String array of client agents
      * @return {@link ClientConfigurationBuilder}
      */
@@ -85,12 +92,14 @@ public class ClientConfigurationBuilder {
     }
 
     /**
-     * Build a {@link Config} with the given parameters.
-     * @return {@link Config}
+     * Build a {@link ClientConfiguration} with the given parameters.
+     *
+     * @return {@link ClientConfiguration}
      */
-    public Config build() {
+    public ClientConfiguration build() {
+        Assert.notNull(this.hostUrl, "Host URL must not be null");
         Assert.notNull(this.apiKey, "API Key must not be null");
-        return new Config(this.hostUrl, this.apiKey, this.jsonHandler,
-                this.clientAgents);
+        return new DefaultClientConfiguration(this.hostUrl, this.apiKey,
+                this.jsonHandler, this.clientAgents);
     }
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/DefaultClientConfiguration.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/DefaultClientConfiguration.java
@@ -1,0 +1,60 @@
+package io.vanslog.spring.data.meilisearch.client;
+
+import com.meilisearch.sdk.Config;
+import com.meilisearch.sdk.json.JsonHandler;
+
+/**
+ * Default implementation of {@link ClientConfiguration}.
+ *
+ * @author Junghoon Ban
+ */
+public class DefaultClientConfiguration implements ClientConfiguration {
+
+    private final String hostUrl;
+    private final String apiKey;
+    private final JsonHandler jsonHandler;
+    private final String[] clientAgents;
+    private final Config config;
+
+    /**
+     * Create a new {@link DefaultClientConfiguration}.
+     * @param hostUrl the host url
+     * @param apiKey the api key
+     * @param jsonHandler the json handler
+     * @param clientAgents the client agents
+     */
+    public DefaultClientConfiguration(String hostUrl, String apiKey,
+                                      JsonHandler jsonHandler,
+                                      String[] clientAgents) {
+        this.hostUrl = hostUrl;
+        this.apiKey = apiKey;
+        this.jsonHandler = jsonHandler;
+        this.clientAgents = clientAgents;
+        this.config = new Config(hostUrl, apiKey, jsonHandler, clientAgents);
+    }
+
+    @Override
+    public String getHostUrl() {
+        return hostUrl;
+    }
+
+    @Override
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    @Override
+    public JsonHandler getJsonHandler() {
+        return jsonHandler;
+    }
+
+    @Override
+    public String[] getClientAgents() {
+        return clientAgents;
+    }
+
+    @Override
+    public Config getConfig() {
+        return config;
+    }
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfiguration.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfiguration.java
@@ -1,7 +1,7 @@
 package io.vanslog.spring.data.meilisearch.config;
 
 import com.meilisearch.sdk.Client;
-import com.meilisearch.sdk.Config;
+import io.vanslog.spring.data.meilisearch.client.ClientConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -19,7 +19,7 @@ public abstract class MeilisearchConfiguration {
      * @return {@link com.meilisearch.sdk.Config}
      */
     @Bean(name = "meilisearchClientConfiguration")
-    public abstract Config clientConfiguration();
+    public abstract ClientConfiguration clientConfiguration();
 
     /**
      * Create a Meilisearch client.
@@ -27,7 +27,7 @@ public abstract class MeilisearchConfiguration {
      * @return {@link com.meilisearch.sdk.Client}
      */
     @Bean(name = "meilisearchClient")
-    public Client meilisearchClient(Config clientConfiguration) {
-        return new Client(clientConfiguration);
+    public Client meilisearchClient(ClientConfiguration clientConfiguration) {
+        return new Client(clientConfiguration.getConfig());
     }
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfiguration.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfiguration.java
@@ -16,7 +16,7 @@ public abstract class MeilisearchConfiguration {
 
     /**
      * Create a Meilisearch client configuration.
-     * @return {@link com.meilisearch.sdk.Config}
+     * @return {@link ClientConfiguration}
      */
     @Bean(name = "meilisearchClientConfiguration")
     public abstract ClientConfiguration clientConfiguration();

--- a/src/test/java/io/vanslog/spring/data/meilisearch/client/ClientConfigurationTest.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/client/ClientConfigurationTest.java
@@ -13,7 +13,7 @@ class ClientConfigurationTest {
 
     @Test
     void shouldBuildConfiguration() {
-        Config clientConfiguration = ClientConfiguration.builder()
+        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
                 .connectedToLocalhost()
                 .withApiKey("masterKey")
                 .withGsonJsonHandler()
@@ -24,7 +24,6 @@ class ClientConfigurationTest {
         assertThat(clientConfiguration.getApiKey()).isEqualTo("masterKey");
         assertThat(clientConfiguration.getJsonHandler()).isInstanceOf(
                 GsonJsonHandler.class);
-        assertThat(clientConfiguration.getHeaders().get("User-Agent")).contains(
-                "Meilisearch Java");
+        assertThat(clientConfiguration.getClientAgents()).isEmpty();
     }
 }

--- a/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfigurationTest.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfigurationTest.java
@@ -28,7 +28,7 @@ class MeilisearchConfigurationTest {
     @Configuration
     static class CustomConfiguration extends MeilisearchConfiguration {
         @Override
-        public Config clientConfiguration() {
+        public ClientConfiguration clientConfiguration() {
             return ClientConfiguration.builder()
                     .connectedToLocalhost()
                     .withApiKey("masterKey")

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchTestConfiguration.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchTestConfiguration.java
@@ -17,7 +17,7 @@ public class MeilisearchTestConfiguration extends MeilisearchConfiguration {
             = MeilisearchConnection.meilisearchConnectionInfo();
 
     @Override
-    public Config clientConfiguration() {
+    public ClientConfiguration clientConfiguration() {
         return ClientConfiguration.builder()
                 .connectedTo(HTTP + meilisearchConnectionInfo.getHost() + ":" +
                         meilisearchConnectionInfo.getPort())


### PR DESCRIPTION
## Related Issue

#39 

## Description

The client is now available by registering the `MeilisearchConfig` type as a bean.
