### PR TITLE
refactor: use gson as default json handler

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,16 @@ Spring Data Implementation for Meilisearch
 
 This library support using Java based `@Configuration` or XML Namespace for configuring the Meilisearch Client.
 
+The elements in the configuration are:
+
+* `host URL`: The Meilisearch host URL
+** default is `http://localhost:7700` in namespace based configuration
+* `API Key`: The Meilisearch API Key
+* `JSON Handler`: The JSON handler for serializing and deserializing the documents
+** default is `GsonJsonHandler`
+* `Client Agents`: The `User-Agent` header for the Meilisearch Client
+** default is empty array
+
 === Annotation based configuration
 
 [source,java]
@@ -24,11 +34,12 @@ public class CustomConfiguration extends MeilisearchConfiguration {
     return ClientConfiguration.builder()
         .connectedToLocalhost()
         .withApiKey("masterKey")
-        .withGsonJsonHandler()
         .build();
   }
 }
 ----
+
+The `host URL` and `API Key` are required configuration.
 
 === Namespace based configuration
 
@@ -41,10 +52,12 @@ public class CustomConfiguration extends MeilisearchConfiguration {
   xsi:schemaLocation="http://www.vanslog.io/spring/data/meilisearch http://www.vanslog.io/spring/data/meilisearch/spring-meilisearch-1.0.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-  <meilisearch:meilisearch-client id="meilisearchClient"
-    api-key="masterKey" json-handler="GSON"/>
+  <meilisearch:meilisearch-client id="meilisearchClient" api-key="masterKey"/>
 </beans>
 ----
+
+The `API Key` is required configuration.
+The Host URL is set to `http://localhost:7700` unless otherwise specified.
 
 == Document Definition
 

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/ClientConfigurationBuilder.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/ClientConfigurationBuilder.java
@@ -24,7 +24,7 @@ public class ClientConfigurationBuilder {
      * Create a new {@link ClientConfigurationBuilder}.
      */
     public ClientConfigurationBuilder() {
-        this.jsonHandler = new JacksonJsonHandler();
+        this.jsonHandler = new GsonJsonHandler();
         this.clientAgents = new String[0];
     }
 

--- a/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
+++ b/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
@@ -33,10 +33,10 @@
                             </xsd:documentation>
                         </xsd:annotation>
                     </xsd:attribute>
-                    <xsd:attribute name="json-handler" default="JACKSON">
+                    <xsd:attribute name="json-handler" default="GSON">
                         <xsd:annotation>
                             <xsd:documentation>
-                                <![CDATA[The enum value of java: io.vanslog.spring.data.meilisearch.config.JsonHandlerBuilder. The default is JACKSON.]]>
+                                <![CDATA[The enum value of java: io.vanslog.spring.data.meilisearch.config.JsonHandlerBuilder. The default is GSON.]]>
                             </xsd:documentation>
                         </xsd:annotation>
                         <xsd:simpleType>

--- a/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchNamespaceHandlerTest.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchNamespaceHandlerTest.java
@@ -27,7 +27,7 @@ class MeilisearchNamespaceHandlerTest {
     }
 
     @Test
-    void shouldMakeJacksonAsDefaultJsonHandler()
+    void shouldUseGsonAsDefaultJsonHandler()
             throws NoSuchFieldException, IllegalAccessException {
         Client client = (Client) context.getBean("meilisearchClient");
 
@@ -36,6 +36,6 @@ class MeilisearchNamespaceHandlerTest {
         jsonHandlerField.setAccessible(true);
         assertThat(jsonHandlerField.get(client))
                 .isInstanceOf(
-                        com.meilisearch.sdk.json.JacksonJsonHandler.class);
+                        com.meilisearch.sdk.json.GsonJsonHandler.class);
     }
 }


### PR DESCRIPTION
## Related Issue

#41 

## Description

Currently, when using Jackson with the meilisearch java client, an error occurs.
The official library also recommends using gson, so we use gson as the default json handler.
