### PR TITLE
refactor(core): return null if document not found

### DIFF
--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchOperations.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchOperations.java
@@ -1,6 +1,7 @@
 package io.vanslog.spring.data.meilisearch.core;
 
 import java.util.List;
+import org.springframework.lang.Nullable;
 
 /**
  * The operations for <a href="https://www.meilisearch.com/docs/reference/api/overview">Meilisearch APIs</a>.
@@ -37,6 +38,7 @@ public interface MeilisearchOperations {
      * @param <T>        the type of the entity
      * @return the entity with the given document id or {@literal null} if none found
      */
+    @Nullable
     <T> T get(String documentId, Class<T> clazz);
 
     /**

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplate.java
@@ -2,6 +2,7 @@ package io.vanslog.spring.data.meilisearch.core;
 
 import com.meilisearch.sdk.Client;
 import com.meilisearch.sdk.Index;
+import com.meilisearch.sdk.exceptions.MeilisearchApiException;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.json.GsonJsonHandler;
 import com.meilisearch.sdk.json.JsonHandler;
@@ -86,11 +87,16 @@ public class MeilisearchTemplate implements MeilisearchOperations {
     }
 
     @Override
+    @Nullable
     public <T> T get(String documentId, Class<T> clazz) {
         Index index = getIndexFor(clazz);
         try {
             return index.getDocument(documentId, clazz);
-        } catch (RuntimeException | MeilisearchException e) {
+        } catch (MeilisearchException e) {
+            MeilisearchApiException ex = (MeilisearchApiException) e;
+            if (ex.getCode().equals("document_not_found")) {
+                return null;
+            }
             throw new UncategorizedMeilisearchException("Failed to get entity.", e);
         }
     }

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateTest.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateTest.java
@@ -60,11 +60,8 @@ class MeilisearchTemplateTest {
         meilisearchTemplate.save(movie1);
         meilisearchTemplate.delete(movie1);
 
-        Throwable thrown =
-                catchThrowable(() -> meilisearchTemplate.get("1", Movie.class));
-
-        assertThat(thrown).isInstanceOf(
-                UncategorizedMeilisearchException.class);
+        Movie saved = meilisearchTemplate.get("1", Movie.class);
+        assertThat(saved).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Related Issue

#51

## Description

If the Meilisearch client's error code is document not found, cause a null return instead of throwing an exception.
