### PR TITLE
fix(core): troubleshooting multiget filtering 

### DIFF
--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplate.java
@@ -113,11 +113,9 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 
     @Override
     public <T> List<T> multiGet(Class<T> clazz, List<String> documentIds) {
-        return documentIds.stream()
-                .map(id -> this.multiGet(clazz).stream()
-                        .filter(entity -> getDocumentIdFor(entity).equals(id))
-                        .findFirst()
-                        .orElse(null))
+        List<T> entities = multiGet(clazz);
+        return entities.stream()
+                .filter(entity -> documentIds.contains(getDocumentIdFor(entity)))
                 .toList();
     }
 

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateTest.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateTest.java
@@ -103,9 +103,11 @@ class MeilisearchTemplateTest {
         List<Movie> movies = List.of(movie1, movie2, movie3);
 
         meilisearchTemplate.save(movies);
-        List<Movie> saved = meilisearchTemplate.multiGet(Movie.class, List.of("1", "2"));
+        List<Movie> saved = meilisearchTemplate.multiGet(Movie.class, List.of("1", "3", "4"));
 
         assertThat(saved.size()).isEqualTo(2);
+        assertThat(saved.get(0).getTitle()).isEqualTo(movie1.getTitle());
+        assertThat(saved.get(1).getTitle()).isEqualTo(movie3.getTitle());
     }
 
     @Test


### PR DESCRIPTION
## Related Issue

#52 

## Description

Fix incorrect filtering logic of `multiGet(Class<T> clazz, List<String> documentIds)` method.
