### PR TITLE
fix(core): resolve exists method fails to return false

### DIFF
--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplate.java
@@ -121,12 +121,7 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 
     @Override
     public boolean exists(String documentId, Class<?> clazz) {
-        Index index = getIndexFor(clazz);
-        try {
-            return index.getDocument(documentId, clazz) != null;
-        } catch (MeilisearchException e) {
-            throw new UncategorizedMeilisearchException("Failed to check existence.", e);
-        }
+        return this.get(documentId, clazz) != null;
     }
 
     @Override

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateTest.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateTest.java
@@ -94,8 +94,12 @@ class MeilisearchTemplateTest {
     @Test
     void shouldExistsDocument() {
         meilisearchTemplate.save(movie1);
+
         boolean exists = meilisearchTemplate.exists("1", Movie.class);
+        boolean nonExists = meilisearchTemplate.exists("2", Movie.class);
+
         assertThat(exists).isTrue();
+        assertThat(nonExists).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Related Issue

#55 

## Description

Modify it to use the template's member method, `get(String documentId, Class<T> clazz)`.
