### PR TITLE
Fix no matching constructor found in class 'MeilisearchTemplate'

### DIFF
--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplate.java
@@ -55,10 +55,14 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 	private final MeilisearchClient client;
 	private final MeilisearchConverter meilisearchConverter;
 
-	public MeilisearchTemplate(MeilisearchClient client, @Nullable MeilisearchConverter meilisearchConverter) {
+	public MeilisearchTemplate(MeilisearchClient client) {
 		this.client = client;
-		this.meilisearchConverter = meilisearchConverter != null ? meilisearchConverter
-				: new MappingMeilisearchConverter(new SimpleMeilisearchMappingContext());
+		this.meilisearchConverter = new MappingMeilisearchConverter(new SimpleMeilisearchMappingContext());
+	}
+
+	public MeilisearchTemplate(MeilisearchClient client, MeilisearchConverter meilisearchConverter) {
+		this.client = client;
+		this.meilisearchConverter = meilisearchConverter;
 	}
 
 	@Override


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.

When contributing, please make sure an issue exists in issue tracker and comment on this issue with how you want to address it. By this we not only know that someone is working on an issue, we can also align architectural questions and possible solutions before work is invested . We so can prevent that much work is put into Pull Requests that have little or no chances of being merged.

Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/junghoon-vans/spring-data-meilisearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #92 
