### PR TITLE
Improve findAll method in MeilisearchRepository.

### DIFF
--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplate.java
@@ -142,7 +142,13 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 	@Override
 	public long count(Class<?> clazz) {
 		String indexUid = getIndexUidFor(clazz);
-		return execute(client -> client.index(indexUid).getDocuments(clazz).getTotal()).longValue();
+
+		DocumentsQuery query = new DocumentsQuery();
+		query.setOffset(0);
+		query.setLimit(0);
+
+		return execute(client -> client.index(indexUid) //
+				.getDocuments(query, clazz).getTotal()).longValue();
 	}
 
 	@Override
@@ -226,6 +232,7 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 
 	/**
 	 * Handle the given {@link MeilisearchApiException}.
+	 * 
 	 * @param e the {@link MeilisearchApiException} to handle
 	 */
 	private void handleApiException(MeilisearchApiException e) {

--- a/src/main/java/io/vanslog/spring/data/meilisearch/repository/support/SimpleMeilisearchRepository.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/repository/support/SimpleMeilisearchRepository.java
@@ -139,6 +139,7 @@ public class SimpleMeilisearchRepository<T, ID> implements MeilisearchRepository
 
 		String[] sortOptions = convertSortToSortOptions(sort);
 		SearchRequest searchRequest = SearchRequest.builder() //
+				.limit((int) meilisearchOperations.count(entityType)) //
 				.sort(sortOptions).build();
 
 		return meilisearchOperations.search(searchRequest, entityType);

--- a/src/main/java/io/vanslog/spring/data/meilisearch/repository/support/SimpleMeilisearchRepository.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/repository/support/SimpleMeilisearchRepository.java
@@ -84,11 +84,6 @@ public class SimpleMeilisearchRepository<T, ID> implements MeilisearchRepository
 	}
 
 	@Override
-	public Iterable<T> findAll() {
-		return meilisearchOperations.multiGet(entityType);
-	}
-
-	@Override
 	public Iterable<T> findAllById(Iterable<ID> ids) {
 		List<String> idList = new ArrayList<>();
 		ids.forEach(id -> idList.add(stringIdRepresentation(id)));
@@ -127,6 +122,15 @@ public class SimpleMeilisearchRepository<T, ID> implements MeilisearchRepository
 	@Override
 	public void deleteAll() {
 		meilisearchOperations.deleteAll(entityType);
+	}
+
+	@Override
+	public Iterable<T> findAll() {
+		SearchRequest searchRequest = SearchRequest.builder() //
+				.limit((int) meilisearchOperations.count(entityType)) //
+				.build();
+
+		return meilisearchOperations.search(searchRequest, entityType);
 	}
 
 	@Override


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.

When contributing, please make sure an issue exists in issue tracker and comment on this issue with how you want to address it. By this we not only know that someone is working on an issue, we can also align architectural questions and possible solutions before work is invested . We so can prevent that much work is put into Pull Requests that have little or no chances of being merged.

Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/junghoon-vans/spring-data-meilisearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

The changes are as follows

- Change `findAll()` method using search operation
- Remove limit on the number of results in `findAll(Sort sort)`
- Optimize the count method

## What specifically changed

Now `findAll()`, `findAll(Sort sort)`, and `findAll(Pageable pageable)` perform [search](https://www.meilisearch.com/docs/reference/api/search) operations. 
On the other hand, `findById` and `findAllById` each use the [Get one document](https://www.meilisearch.com/docs/reference/api/documents#get-one-document) and [Get documents](https://www.meilisearch.com/docs/reference/api/documents#get-documents-with-post) APIs.

Closes #123 
