### PR TITLE
Resolving ClassNotFoundException: okhttp3.MediaType by Upgrading Meilisearch Java SDK to 0.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
         <springdata.commons>3.2.0-SNAPSHOT</springdata.commons>
-        <meilisearch-java>0.14.3</meilisearch-java>
+        <meilisearch-java>0.15.0</meilisearch-java>
         <testcontainers-meilisearch>1.0.5</testcontainers-meilisearch>
 
         <java-module-name>spring.data.meilisearch</java-module-name>


### PR DESCRIPTION
### Background
This PR addresses a critical java.lang.ClassNotFoundException: okhttp3.MediaType error encountered in projects utilizing the Meilisearch Java SDK. This exception occurs at runtime because the okhttp3.MediaType class cannot be found, which typically points to a dependency conflict or a missing transitive dependency within the SDK's previous versions.

### Solution
The root cause of this error has been identified as a specific dependency issue within older versions of the Meilisearch Java SDK. By upgrading the Meilisearch Java SDK to version 0.15.0, we have successfully resolved this ClassNotFoundException.

Version 0.15.0 includes significant updates to dependency management and resolves potential conflicts, directly contributing to the fix for the okhttp3.MediaType related problem.

### Changes
Updated the Meilisearch Java SDK version to 0.15.0 in the project's pom.xml 

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/junghoon-vans/spring-data-meilisearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #168 
