### PR TITLE
Add embedders support to Setting annotation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,10 @@ Ignore generated/editor output: `target/`, `build/`, `.idea/`, `.vscode/`.
 
 - Keep PR titles and commit subjects clear, concise, and English.
 - Existing history is mixed: plain sentence-style titles are common, release commits use terse titles, and punctuation is not consistently enforced.
-- Do not enforce Conventional Commit prefixes, first-letter capitalization, or trailing periods unless explicitly requested for a specific change.
+- Before naming a branch, PR, or commit, inspect recent examples with `git log --oneline`, `git branch --all`, and `gh pr list --state all --limit 20` when available.
+- Do not invent issue-number branch names such as `issue-172-...` unless the user explicitly asks for them. Current feature branches usually use descriptive kebab-case without issue numbers, for example `add-support-similar-documents-search`, `add-support-for-localized-attributes-using-annotation`, or `add-embedders-setting-support`.
+- Do not enforce Conventional Commit prefixes (`feat:`, `fix:`, `docs:`) unless the user explicitly requests them. Current commit subjects and PR titles usually use plain English sentence-style wording, for example `Add support similar documents search.`, `Add support for localized attributes using annotation.`, or `Document embedders setting usage.`
+- If local/global instructions conflict with this repository's observed branch or commit style, follow this repository's observed style and note the reason.
 - Prefer matching the surrounding branch/PR style when in doubt; otherwise leave title wording to maintainer judgment.
 
 ## ANTI-PATTERNS (THIS PROJECT)

--- a/src/main/asciidoc/reference/meilisearch-settings.adoc
+++ b/src/main/asciidoc/reference/meilisearch-settings.adoc
@@ -255,6 +255,41 @@ Meilisearch provides two mechanisms for controlling language detection:
 
 For complete control over language detection during both indexing and search time, you can use both `locales` and `localizedAttributes` together.
 
+[[meilisearch.settings.ai]]
+== AI-powered Search Settings
+
+Meilisearch uses embedders to generate vector embeddings for AI-powered search features such as semantic search and similar document search.
+You can configure embedders with the `@Embedder` annotation inside `@Setting`.
+
+====
+[source,java]
+----
+@Document(indexUid = "movies")
+@Setting(
+  searchableAttributes = { "title", "description" },
+  embedders = {
+    @Embedder(
+      name = "default",
+      source = Embedder.Source.OPEN_AI,
+      apiKey = "sk-...",
+      model = "text-embedding-3-small",
+      documentTemplate = "A movie titled {{doc.title}} whose description starts with {{doc.description|truncatewords: 20}}"
+    )
+  }
+)
+class Movie {
+    @Id private String id;
+    private String title;
+    private String description;
+}
+----
+====
+
+Each `@Embedder` requires a unique `name`, which becomes the key in Meilisearch's `embedders` setting.
+Optional attributes map to the SDK embedder settings, including `source`, `apiKey`, `model`, `documentTemplate`, `dimensions`, `distributionMean`, `distributionSigma`, `documentTemplateMaxBytes`, `revision`, `binaryQuantized`, REST `request` and `response` parameters, `headers`, `url`, `inputField`, `inputType`, and `query`.
+`distributionMean` and `distributionSigma` must be configured together.
+`request`, `response`, and `headers` use `@EmbedderParameter` and currently support flat string key-value parameters.
+
 [[meilisearch.settings.performance]]
 == Performance Settings
 

--- a/src/main/java/io/vanslog/spring/data/meilisearch/annotations/Embedder.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/annotations/Embedder.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.data.annotation.Persistent;
+
+/**
+ * Meilisearch embedder setting.
+ *
+ * @author Junghoon Ban
+ * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#embedders">Embedders</a>
+ */
+@Persistent
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE })
+public @interface Embedder {
+
+	String name();
+
+	Source source() default Source.DEFAULT;
+
+	String apiKey() default "";
+
+	String model() default "";
+
+	String documentTemplate() default "";
+
+	int dimensions() default -1;
+
+	double distributionMean() default Double.NaN;
+
+	double distributionSigma() default Double.NaN;
+
+	EmbedderParameter[] request() default {};
+
+	EmbedderParameter[] response() default {};
+
+	int documentTemplateMaxBytes() default -1;
+
+	String revision() default "";
+
+	EmbedderParameter[] headers() default {};
+
+	TriState binaryQuantized() default TriState.DEFAULT;
+
+	String url() default "";
+
+	String[] inputField() default {};
+
+	InputType inputType() default InputType.DEFAULT;
+
+	String query() default "";
+
+	enum Source {
+
+		DEFAULT, OPEN_AI, HUGGING_FACE, OLLAMA, REST, USER_PROVIDED
+	}
+
+	enum InputType {
+
+		DEFAULT, TEXT, TEXT_ARRAY
+	}
+
+	enum TriState {
+
+		DEFAULT, TRUE, FALSE
+	}
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/annotations/EmbedderParameter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/annotations/EmbedderParameter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.data.annotation.Persistent;
+
+/**
+ * Key-value parameter used by Meilisearch embedder settings.
+ *
+ * @author Junghoon Ban
+ */
+@Persistent
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE })
+public @interface EmbedderParameter {
+
+	String name();
+
+	String value();
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/annotations/Setting.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/annotations/Setting.java
@@ -137,4 +137,11 @@ public @interface Setting {
 	 *      attributes</a>
 	 */
 	LocalizedAttribute[] localizedAttributes() default {};
+
+	/**
+	 * defines the embedders configuration for AI-powered search
+	 *
+	 * @see <a href="https://www.meilisearch.com/docs/reference/api/settings#embedders">Embedders</a>
+	 */
+	Embedder[] embedders() default {};
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/mapping/SimpleMeilisearchPersistentEntity.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/mapping/SimpleMeilisearchPersistentEntity.java
@@ -251,9 +251,9 @@ public class SimpleMeilisearchPersistentEntity<T> extends BasicPersistentEntity<
 			Optional.of(embedder.source()).filter(it -> it != Embedder.Source.DEFAULT)
 					.map(it -> com.meilisearch.sdk.model.EmbedderSource.valueOf(it.name()))
 					.ifPresent(meiliEmbedder::setSource);
-			Optional.of(embedder.apiKey()).filter(it -> !it.isEmpty()).ifPresent(meiliEmbedder::setApiKey);
-			Optional.of(embedder.model()).filter(it -> !it.isEmpty()).ifPresent(meiliEmbedder::setModel);
-			Optional.of(embedder.documentTemplate()).filter(it -> !it.isEmpty()).ifPresent(meiliEmbedder::setDocumentTemplate);
+			Optional.of(embedder.apiKey()).filter(it -> !it.isBlank()).ifPresent(meiliEmbedder::setApiKey);
+			Optional.of(embedder.model()).filter(it -> !it.isBlank()).ifPresent(meiliEmbedder::setModel);
+			Optional.of(embedder.documentTemplate()).filter(it -> !it.isBlank()).ifPresent(meiliEmbedder::setDocumentTemplate);
 			Optional.of(embedder.dimensions()).filter(it -> it > 0).ifPresent(meiliEmbedder::setDimensions);
 			boolean hasDistributionMean = !Double.isNaN(embedder.distributionMean());
 			boolean hasDistributionSigma = !Double.isNaN(embedder.distributionSigma());
@@ -263,37 +263,41 @@ public class SimpleMeilisearchPersistentEntity<T> extends BasicPersistentEntity<
 				meiliEmbedder.setDistribution(com.meilisearch.sdk.model.EmbedderDistribution
 						.custom(embedder.distributionMean(), embedder.distributionSigma()));
 			}
-			Optional.of(embedder.request()).filter(it -> it.length > 0).map(this::createParameterMap)
+			Optional.of(embedder.request()).filter(it -> it.length > 0).map(SettingsParameter::createParameterMap)
 					.ifPresent(meiliEmbedder::setRequest);
-			Optional.of(embedder.response()).filter(it -> it.length > 0).map(this::createParameterMap)
+			Optional.of(embedder.response()).filter(it -> it.length > 0).map(SettingsParameter::createParameterMap)
 					.ifPresent(meiliEmbedder::setResponse);
 			Optional.of(embedder.documentTemplateMaxBytes()).filter(it -> it > 0)
 					.ifPresent(meiliEmbedder::setDocumentTemplateMaxBytes);
-			Optional.of(embedder.revision()).filter(it -> !it.isEmpty()).ifPresent(meiliEmbedder::setRevision);
-			Optional.of(embedder.headers()).filter(it -> it.length > 0).map(this::createHeaderMap)
+			Optional.of(embedder.revision()).filter(it -> !it.isBlank()).ifPresent(meiliEmbedder::setRevision);
+			Optional.of(embedder.headers()).filter(it -> it.length > 0).map(SettingsParameter::createHeaderMap)
 					.ifPresent(meiliEmbedder::setHeaders);
 			Optional.of(embedder.binaryQuantized()).filter(it -> it != Embedder.TriState.DEFAULT)
 					.map(it -> it == Embedder.TriState.TRUE).ifPresent(meiliEmbedder::setBinaryQuantized);
-			Optional.of(embedder.url()).filter(it -> !it.isEmpty()).ifPresent(meiliEmbedder::setUrl);
+			Optional.of(embedder.url()).filter(it -> !it.isBlank()).ifPresent(meiliEmbedder::setUrl);
 			Optional.of(embedder.inputField()).filter(it -> it.length > 0).ifPresent(meiliEmbedder::setInputField);
 			Optional.of(embedder.inputType()).filter(it -> it != Embedder.InputType.DEFAULT)
 					.map(it -> com.meilisearch.sdk.model.EmbedderInputType.valueOf(it.name()))
 					.ifPresent(meiliEmbedder::setInputType);
-			Optional.of(embedder.query()).filter(it -> !it.isEmpty()).ifPresent(meiliEmbedder::setQuery);
+			Optional.of(embedder.query()).filter(it -> !it.isBlank()).ifPresent(meiliEmbedder::setQuery);
 			return meiliEmbedder;
 		}
 
-		private Map<String, Object> createParameterMap(EmbedderParameter[] parameters) {
+		private static Map<String, Object> createParameterMap(EmbedderParameter[] parameters) {
 			var parameterMap = new HashMap<String, Object>();
 			for (EmbedderParameter parameter : parameters) {
+				Assert.hasText(parameter.name(), "Embedder parameter name must not be blank");
+				Assert.isTrue(!parameterMap.containsKey(parameter.name()), "Embedder parameter name must be unique");
 				parameterMap.put(parameter.name(), parameter.value());
 			}
 			return parameterMap;
 		}
 
-		private Map<String, String> createHeaderMap(EmbedderParameter[] parameters) {
+		private static Map<String, String> createHeaderMap(EmbedderParameter[] parameters) {
 			var headerMap = new HashMap<String, String>();
 			for (EmbedderParameter parameter : parameters) {
+				Assert.hasText(parameter.name(), "Embedder parameter name must not be blank");
+				Assert.isTrue(!headerMap.containsKey(parameter.name()), "Embedder parameter name must be unique");
 				headerMap.put(parameter.name(), parameter.value());
 			}
 			return headerMap;

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/mapping/SimpleMeilisearchPersistentEntity.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/mapping/SimpleMeilisearchPersistentEntity.java
@@ -16,6 +16,8 @@
 package io.vanslog.spring.data.meilisearch.core.mapping;
 
 import io.vanslog.spring.data.meilisearch.annotations.Document;
+import io.vanslog.spring.data.meilisearch.annotations.Embedder;
+import io.vanslog.spring.data.meilisearch.annotations.EmbedderParameter;
 import io.vanslog.spring.data.meilisearch.annotations.Faceting;
 import io.vanslog.spring.data.meilisearch.annotations.LocalizedAttribute;
 import io.vanslog.spring.data.meilisearch.annotations.Pagination;
@@ -25,6 +27,7 @@ import io.vanslog.spring.data.meilisearch.annotations.TypoTolerance;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.beans.BeansException;
@@ -129,6 +132,7 @@ public class SimpleMeilisearchPersistentEntity<T> extends BasicPersistentEntity<
 		@Nullable private String[] separatorTokens;
 		@Nullable private String[] nonSeparatorTokens;
 		@Nullable private LocalizedAttribute[] localizedAttributes;
+		@Nullable private Embedder[] embedders;
 
 		public SettingsParameter(@Nullable Setting setting, @Nullable Pagination pagination,
 				@Nullable TypoTolerance typoTolerance, @Nullable Faceting faceting) {
@@ -152,6 +156,7 @@ public class SimpleMeilisearchPersistentEntity<T> extends BasicPersistentEntity<
 				this.separatorTokens = setting.separatorTokens();
 				this.nonSeparatorTokens = setting.nonSeparatorTokens();
 				this.localizedAttributes = setting.localizedAttributes();
+				this.embedders = setting.embedders();
 			}
 		}
 
@@ -182,6 +187,8 @@ public class SimpleMeilisearchPersistentEntity<T> extends BasicPersistentEntity<
 					.map(attrs -> Arrays.stream(attrs).map(this::createMeiliLocalizedAttribute)
 							.toArray(com.meilisearch.sdk.model.LocalizedAttribute[]::new))
 					.ifPresent(settings::setLocalizedAttributes);
+			Optional.ofNullable(embedders).filter(it -> it.length > 0)
+					.ifPresent(it -> settings.setEmbedders(createEmbedderMap(it)));
 
 			return settings;
 		}
@@ -227,6 +234,69 @@ public class SimpleMeilisearchPersistentEntity<T> extends BasicPersistentEntity<
 			meiliLocalizedAttributes.setAttributePatterns(localizedAttribute.attributePatterns());
 			meiliLocalizedAttributes.setLocales(localizedAttribute.locales());
 			return meiliLocalizedAttributes;
+		}
+
+		private HashMap<String, com.meilisearch.sdk.model.Embedder> createEmbedderMap(Embedder[] embedders) {
+			var embedderMap = new HashMap<String, com.meilisearch.sdk.model.Embedder>();
+			for (Embedder embedder : embedders) {
+				Assert.hasText(embedder.name(), "Embedder name must not be blank");
+				Assert.isTrue(!embedderMap.containsKey(embedder.name()), "Embedder name must be unique");
+				embedderMap.put(embedder.name(), createMeiliEmbedder(embedder));
+			}
+			return embedderMap;
+		}
+
+		private com.meilisearch.sdk.model.Embedder createMeiliEmbedder(Embedder embedder) {
+			var meiliEmbedder = new com.meilisearch.sdk.model.Embedder();
+			Optional.of(embedder.source()).filter(it -> it != Embedder.Source.DEFAULT)
+					.map(it -> com.meilisearch.sdk.model.EmbedderSource.valueOf(it.name()))
+					.ifPresent(meiliEmbedder::setSource);
+			Optional.of(embedder.apiKey()).filter(it -> !it.isEmpty()).ifPresent(meiliEmbedder::setApiKey);
+			Optional.of(embedder.model()).filter(it -> !it.isEmpty()).ifPresent(meiliEmbedder::setModel);
+			Optional.of(embedder.documentTemplate()).filter(it -> !it.isEmpty()).ifPresent(meiliEmbedder::setDocumentTemplate);
+			Optional.of(embedder.dimensions()).filter(it -> it > 0).ifPresent(meiliEmbedder::setDimensions);
+			boolean hasDistributionMean = !Double.isNaN(embedder.distributionMean());
+			boolean hasDistributionSigma = !Double.isNaN(embedder.distributionSigma());
+			Assert.isTrue(hasDistributionMean == hasDistributionSigma,
+					"Embedder distributionMean and distributionSigma must be configured together");
+			if (hasDistributionMean) {
+				meiliEmbedder.setDistribution(com.meilisearch.sdk.model.EmbedderDistribution
+						.custom(embedder.distributionMean(), embedder.distributionSigma()));
+			}
+			Optional.of(embedder.request()).filter(it -> it.length > 0).map(this::createParameterMap)
+					.ifPresent(meiliEmbedder::setRequest);
+			Optional.of(embedder.response()).filter(it -> it.length > 0).map(this::createParameterMap)
+					.ifPresent(meiliEmbedder::setResponse);
+			Optional.of(embedder.documentTemplateMaxBytes()).filter(it -> it > 0)
+					.ifPresent(meiliEmbedder::setDocumentTemplateMaxBytes);
+			Optional.of(embedder.revision()).filter(it -> !it.isEmpty()).ifPresent(meiliEmbedder::setRevision);
+			Optional.of(embedder.headers()).filter(it -> it.length > 0).map(this::createHeaderMap)
+					.ifPresent(meiliEmbedder::setHeaders);
+			Optional.of(embedder.binaryQuantized()).filter(it -> it != Embedder.TriState.DEFAULT)
+					.map(it -> it == Embedder.TriState.TRUE).ifPresent(meiliEmbedder::setBinaryQuantized);
+			Optional.of(embedder.url()).filter(it -> !it.isEmpty()).ifPresent(meiliEmbedder::setUrl);
+			Optional.of(embedder.inputField()).filter(it -> it.length > 0).ifPresent(meiliEmbedder::setInputField);
+			Optional.of(embedder.inputType()).filter(it -> it != Embedder.InputType.DEFAULT)
+					.map(it -> com.meilisearch.sdk.model.EmbedderInputType.valueOf(it.name()))
+					.ifPresent(meiliEmbedder::setInputType);
+			Optional.of(embedder.query()).filter(it -> !it.isEmpty()).ifPresent(meiliEmbedder::setQuery);
+			return meiliEmbedder;
+		}
+
+		private Map<String, Object> createParameterMap(EmbedderParameter[] parameters) {
+			var parameterMap = new HashMap<String, Object>();
+			for (EmbedderParameter parameter : parameters) {
+				parameterMap.put(parameter.name(), parameter.value());
+			}
+			return parameterMap;
+		}
+
+		private Map<String, String> createHeaderMap(EmbedderParameter[] parameters) {
+			var headerMap = new HashMap<String, String>();
+			for (EmbedderParameter parameter : parameters) {
+				headerMap.put(parameter.name(), parameter.value());
+			}
+			return headerMap;
 		}
 	}
 }

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/mapping/SimpleMeilisearchPersistentEntityUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/mapping/SimpleMeilisearchPersistentEntityUnitTests.java
@@ -180,6 +180,35 @@ class SimpleMeilisearchPersistentEntityUnitTests {
 		@Id private String id;
 	}
 
+	@Document(indexUid = "movies")
+	@Setting(embedders = @Embedder( //
+			name = "default", //
+			apiKey = " ", //
+			model = " ", //
+			documentTemplate = " ", //
+			revision = " ", //
+			url = " ", //
+			query = " " //
+	))
+	static class EntityWithBlankEmbedderValues {
+		@Id private String id;
+	}
+
+	@Document(indexUid = "movies")
+	@Setting(embedders = @Embedder(name = "default", request = @EmbedderParameter(name = "", value = "{{text}}")))
+	static class EntityWithBlankEmbedderParameterName {
+		@Id private String id;
+	}
+
+	@Document(indexUid = "movies")
+	@Setting(embedders = @Embedder(name = "default", headers = { //
+			@EmbedderParameter(name = "Authorization", value = "Bearer token"), //
+			@EmbedderParameter(name = "Authorization", value = "Bearer other") //
+	}))
+	static class EntityWithDuplicateEmbedderHeaderNames {
+		@Id private String id;
+	}
+
 	@Nested
 	@DisplayName("index uid")
 	class IndexUidTests {
@@ -342,9 +371,39 @@ class SimpleMeilisearchPersistentEntityUnitTests {
 			assertThat(rest.getQuery()).isEqualTo("{{q}}");
 
 			assertThat(minimal.getSource()).isNull();
+			assertThat(minimal.getApiKey()).isNull();
 			assertThat(minimal.getModel()).isNull();
+			assertThat(minimal.getDocumentTemplate()).isNull();
+			assertThat(minimal.getDimensions()).isNull();
 			assertThat(minimal.getDistribution()).isNull();
+			assertThat(minimal.getRequest()).isNull();
+			assertThat(minimal.getResponse()).isNull();
+			assertThat(minimal.getDocumentTemplateMaxBytes()).isNull();
+			assertThat(minimal.getRevision()).isNull();
+			assertThat(minimal.getHeaders()).isNull();
 			assertThat(minimal.getBinaryQuantized()).isFalse();
+			assertThat(minimal.getUrl()).isNull();
+			assertThat(minimal.getInputField()).isNull();
+			assertThat(minimal.getInputType()).isNull();
+			assertThat(minimal.getQuery()).isNull();
+		}
+
+		@Test
+		void shouldIgnoreBlankEmbedderValues() {
+			// given
+			SimpleMeilisearchPersistentEntity<EntityWithBlankEmbedderValues> entity = new SimpleMeilisearchPersistentEntity<>(
+					TypeInformation.of(EntityWithBlankEmbedderValues.class));
+
+			// when
+			var embedder = entity.getDefaultSettings().getEmbedders().get("default");
+
+			// then
+			assertThat(embedder.getApiKey()).isNull();
+			assertThat(embedder.getModel()).isNull();
+			assertThat(embedder.getDocumentTemplate()).isNull();
+			assertThat(embedder.getRevision()).isNull();
+			assertThat(embedder.getUrl()).isNull();
+			assertThat(embedder.getQuery()).isNull();
 		}
 
 		@Test
@@ -378,6 +437,28 @@ class SimpleMeilisearchPersistentEntityUnitTests {
 			// when / then
 			assertThatThrownBy(entity::getDefaultSettings).isInstanceOf(IllegalArgumentException.class)
 					.hasMessageContaining("distributionMean and distributionSigma must be configured together");
+		}
+
+		@Test
+		void shouldRejectBlankEmbedderParameterName() {
+			// given
+			SimpleMeilisearchPersistentEntity<EntityWithBlankEmbedderParameterName> entity = new SimpleMeilisearchPersistentEntity<>(
+					TypeInformation.of(EntityWithBlankEmbedderParameterName.class));
+
+			// when / then
+			assertThatThrownBy(entity::getDefaultSettings).isInstanceOf(IllegalArgumentException.class)
+					.hasMessageContaining("Embedder parameter name must not be blank");
+		}
+
+		@Test
+		void shouldRejectDuplicateEmbedderParameterNames() {
+			// given
+			SimpleMeilisearchPersistentEntity<EntityWithDuplicateEmbedderHeaderNames> entity = new SimpleMeilisearchPersistentEntity<>(
+					TypeInformation.of(EntityWithDuplicateEmbedderHeaderNames.class));
+
+			// when / then
+			assertThatThrownBy(entity::getDefaultSettings).isInstanceOf(IllegalArgumentException.class)
+					.hasMessageContaining("Embedder parameter name must be unique");
 		}
 	}
 	// endregion

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/mapping/SimpleMeilisearchPersistentEntityUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/mapping/SimpleMeilisearchPersistentEntityUnitTests.java
@@ -18,6 +18,8 @@ package io.vanslog.spring.data.meilisearch.core.mapping;
 import static org.assertj.core.api.Assertions.*;
 
 import io.vanslog.spring.data.meilisearch.annotations.Document;
+import io.vanslog.spring.data.meilisearch.annotations.Embedder;
+import io.vanslog.spring.data.meilisearch.annotations.EmbedderParameter;
 import io.vanslog.spring.data.meilisearch.annotations.Faceting;
 import io.vanslog.spring.data.meilisearch.annotations.LocalizedAttribute;
 import io.vanslog.spring.data.meilisearch.annotations.MinWordSizeForTypos;
@@ -116,6 +118,66 @@ class SimpleMeilisearchPersistentEntityUnitTests {
 		private String color;
 		private String productId;
 		private double price;
+	}
+
+	@Document(indexUid = "movies")
+	@Setting(embedders = { //
+			@Embedder( //
+					name = "openai", //
+					source = Embedder.Source.OPEN_AI, //
+					apiKey = "sk-test", //
+					model = "text-embedding-3-small", //
+					documentTemplate = "A movie titled {{doc.title}}", //
+					dimensions = 1536, //
+					documentTemplateMaxBytes = 400, //
+					binaryQuantized = Embedder.TriState.TRUE //
+			), //
+			@Embedder( //
+					name = "rest", //
+					source = Embedder.Source.REST, //
+					url = "https://example.com/embed", //
+					inputField = { "title", "description" }, //
+					inputType = Embedder.InputType.TEXT_ARRAY, //
+					distributionMean = 0.5, //
+					distributionSigma = 0.25, //
+					request = { //
+							@EmbedderParameter(name = "text", value = "{{text}}") //
+					}, //
+					response = { //
+							@EmbedderParameter(name = "embedding", value = "$.embedding") //
+					}, //
+					headers = { //
+							@EmbedderParameter(name = "Authorization", value = "Bearer token") //
+					}, //
+					query = "{{q}}" //
+			), //
+			@Embedder( //
+					name = "minimal", //
+					binaryQuantized = Embedder.TriState.FALSE //
+			) //
+	})
+	static class EntityWithEmbeddersSettings {
+		@Id private String id;
+		private String title;
+		private String description;
+	}
+
+	@Document(indexUid = "movies")
+	@Setting(embedders = @Embedder(name = ""))
+	static class EntityWithBlankEmbedderName {
+		@Id private String id;
+	}
+
+	@Document(indexUid = "movies")
+	@Setting(embedders = { @Embedder(name = "default"), @Embedder(name = "default") })
+	static class EntityWithDuplicateEmbedderNames {
+		@Id private String id;
+	}
+
+	@Document(indexUid = "movies")
+	@Setting(embedders = @Embedder(name = "default", distributionMean = 0.5))
+	static class EntityWithPartialEmbedderDistribution {
+		@Id private String id;
 	}
 
 	@Nested
@@ -242,6 +304,80 @@ class SimpleMeilisearchPersistentEntityUnitTests {
 			// Check pagination settings
 			assertThat(pagination).isNotNull();
 			assertThat(pagination.getMaxTotalHits()).isEqualTo(2000);
+		}
+
+		@Test
+		void shouldReturnEmbeddersSettings() {
+			// given
+			SimpleMeilisearchPersistentEntity<EntityWithEmbeddersSettings> entity = new SimpleMeilisearchPersistentEntity<>(
+					TypeInformation.of(EntityWithEmbeddersSettings.class));
+
+			// when
+			var settings = entity.getDefaultSettings();
+			var embedders = settings.getEmbedders();
+			var openAi = embedders.get("openai");
+			var rest = embedders.get("rest");
+			var minimal = embedders.get("minimal");
+
+			// then
+			assertThat(embedders).hasSize(3);
+
+			assertThat(openAi.getSource()).isEqualTo(com.meilisearch.sdk.model.EmbedderSource.OPEN_AI);
+			assertThat(openAi.getApiKey()).isEqualTo("sk-test");
+			assertThat(openAi.getModel()).isEqualTo("text-embedding-3-small");
+			assertThat(openAi.getDocumentTemplate()).isEqualTo("A movie titled {{doc.title}}");
+			assertThat(openAi.getDimensions()).isEqualTo(1536);
+			assertThat(openAi.getDocumentTemplateMaxBytes()).isEqualTo(400);
+			assertThat(openAi.getBinaryQuantized()).isTrue();
+
+			assertThat(rest.getSource()).isEqualTo(com.meilisearch.sdk.model.EmbedderSource.REST);
+			assertThat(rest.getUrl()).isEqualTo("https://example.com/embed");
+			assertThat(rest.getInputField()).containsExactly("title", "description");
+			assertThat(rest.getInputType()).isEqualTo(com.meilisearch.sdk.model.EmbedderInputType.TEXT_ARRAY);
+			assertThat(rest.getDistribution().getMean()).isEqualTo(0.5);
+			assertThat(rest.getDistribution().getSigma()).isEqualTo(0.25);
+			assertThat(rest.getRequest()).containsEntry("text", "{{text}}");
+			assertThat(rest.getResponse()).containsEntry("embedding", "$.embedding");
+			assertThat(rest.getHeaders()).containsEntry("Authorization", "Bearer token");
+			assertThat(rest.getQuery()).isEqualTo("{{q}}");
+
+			assertThat(minimal.getSource()).isNull();
+			assertThat(minimal.getModel()).isNull();
+			assertThat(minimal.getDistribution()).isNull();
+			assertThat(minimal.getBinaryQuantized()).isFalse();
+		}
+
+		@Test
+		void shouldRejectBlankEmbedderName() {
+			// given
+			SimpleMeilisearchPersistentEntity<EntityWithBlankEmbedderName> entity = new SimpleMeilisearchPersistentEntity<>(
+					TypeInformation.of(EntityWithBlankEmbedderName.class));
+
+			// when / then
+			assertThatThrownBy(entity::getDefaultSettings).isInstanceOf(IllegalArgumentException.class)
+					.hasMessageContaining("Embedder name must not be blank");
+		}
+
+		@Test
+		void shouldRejectDuplicateEmbedderNames() {
+			// given
+			SimpleMeilisearchPersistentEntity<EntityWithDuplicateEmbedderNames> entity = new SimpleMeilisearchPersistentEntity<>(
+					TypeInformation.of(EntityWithDuplicateEmbedderNames.class));
+
+			// when / then
+			assertThatThrownBy(entity::getDefaultSettings).isInstanceOf(IllegalArgumentException.class)
+					.hasMessageContaining("Embedder name must be unique");
+		}
+
+		@Test
+		void shouldRejectPartialEmbedderDistribution() {
+			// given
+			SimpleMeilisearchPersistentEntity<EntityWithPartialEmbedderDistribution> entity = new SimpleMeilisearchPersistentEntity<>(
+					TypeInformation.of(EntityWithPartialEmbedderDistribution.class));
+
+			// when / then
+			assertThatThrownBy(entity::getDefaultSettings).isInstanceOf(IllegalArgumentException.class)
+					.hasMessageContaining("distributionMean and distributionSigma must be configured together");
 		}
 	}
 	// endregion


### PR DESCRIPTION
## Summary
- Add typed `@Embedder` and `@EmbedderParameter` annotations for configuring Meilisearch embedders through `@Setting`.
- Map embedder annotations into SDK `Settings.setEmbedders(...)` with validation for blank or duplicate names and partial distribution settings.
- Document embedder usage and clarify repository branch/commit naming guidance in `AGENTS.md`.

## Verification
- LSP diagnostics on modified Java files
- `./mvnw -Dtest=SimpleMeilisearchPersistentEntityUnitTests test`
- `./mvnw verify -Pci`

Closes #172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for AI-powered search using vector embedders.
  * Support for multiple embedder sources including OpenAI, HuggingFace, Ollama, REST, and custom providers.
  * Configurable embedder settings including API keys, models, document templates, and optimization parameters.

* **Documentation**
  * Added comprehensive guide for configuring AI-powered search settings.
  * Updated contribution guidance with improved examples for branch and commit naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->