### PR TITLE
Release 0.8.0.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ spring-data-meilisearch/
 │   ├── core/                       # template, operations, search result model
 │   └── repository/                 # Spring Data repository bootstrap/runtime
 ├── src/main/resources/             # Spring XML namespace registrations + XSD
-├── src/main/antora/                # Antora reference docs source, playbook, and resources
+├── src/main/antora/                # Antora reference docs source and resources
+├── antora-playbook.yml             # Antora playbook
 └── src/test/java/.../meilisearch/  # unit/integration tests + reusable Meilisearch test harness
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ spring-data-meilisearch/
 │   ├── core/                       # template, operations, search result model
 │   └── repository/                 # Spring Data repository bootstrap/runtime
 ├── src/main/resources/             # Spring XML namespace registrations + XSD
-├── src/main/asciidoc/              # reference docs source; index.adoc includes chapters
+├── src/main/antora/                # Antora reference docs source, playbook, and resources
 └── src/test/java/.../meilisearch/  # unit/integration tests + reusable Meilisearch test harness
 ```
 
@@ -34,7 +34,7 @@ Ignore generated/editor output: `target/`, `build/`, `.idea/`, `.vscode/`.
 | Mapping/settings | `core/mapping/` + `annotations/` | `@Document`, settings annotations, ID/index metadata |
 | Repository behavior | `repository/config/`, `repository/support/` | registrar/config extension/factory/base repository |
 | XML namespace | `config/`, `src/main/resources/` | parser, namespace handler, `spring.handlers`, `spring.schemas`, XSD |
-| Docs | `src/main/asciidoc/` | `index.adoc` includes all reference chapters |
+| Docs | `src/main/antora/` | Antora component, navigation, pages, and resources |
 | Integration tests | `src/test/java/.../junit/jupiter/` | custom Testcontainers-backed harness |
 
 ## CODE MAP
@@ -59,7 +59,7 @@ Ignore generated/editor output: `target/`, `build/`, `.idea/`, `.vscode/`.
 - Checkstyle/no-http and JaCoCo run only with `-Pci`.
 - Formatting is delegated to Spring Data shared IDE formatters from `spring-data-build/etc/ide`; no local `.editorconfig`.
 - PR template asks to use Spring Data formatters, add tests, and update author/date headers on touched/new classes.
-- Reference docs are rooted at `src/main/asciidoc/index.adoc`; generated HTML is under `target/site/reference/html/`.
+- Reference docs are rooted at `src/main/antora/`; generated HTML is under `target/site/`.
 - XML namespace resources are a public contract: `spring.handlers`, `spring.schemas`, and `spring-meilisearch-1.0.xsd` must match parser/docs.
 
 ## DEVELOPMENT PROCESS
@@ -90,7 +90,7 @@ Ignore generated/editor output: `target/`, `build/`, `.idea/`, `.vscode/`.
 - Do not use blank `@Document(indexUid = "")`; mapping rejects blank values.
 - Do not expect >1,000 search results unless `@Pagination(maxTotalHits = ...)` is configured.
 - Do not edit XML namespace docs/resources independently; parser, XSD, `spring.handlers`, `spring.schemas`, and docs must agree.
-- Do not copy XML/JSON handler examples from docs without checking code; `meilisearch-client.adoc` has known casing/name drift.
+- Do not copy XML/JSON handler examples across JavaConfig and XML without checking code; bean names and XML attributes are public contracts.
 
 ## COMMANDS
 
@@ -98,14 +98,14 @@ Ignore generated/editor output: `target/`, `build/`, `.idea/`, `.vscode/`.
 ./mvnw test
 ./mvnw clean install
 ./mvnw verify -Pci
-./mvnw clean install -Pdistribute
+./mvnw -Pantora antora:antora
 ```
 
-Docs output: `target/site/reference/html/index.html`. CI command adds Sonar: `./mvnw verify sonar:sonar -Pci ...`.
+Docs output: `target/site/index.html`. CI command adds Sonar: `./mvnw verify sonar:sonar -Pci ...`.
 
 ## NOTES
 
-- Parent/dependency versions currently target Spring Data snapshots: `spring-data-parent` and `spring-data-commons` are `3.2.0-SNAPSHOT`.
+- Parent/dependency versions follow the active release train in `pom.xml`; release preparation removes `-SNAPSHOT` from project and Spring Data versions.
 - CD publishes on pushes to both `main` and `develop` with `mvn deploy -DskipTests -P central`.
 - `central` profile signs artifacts and uses Sonatype Central Publishing with auto-publish.
-- `src/main/asciidoc/reference/meilisearch-client.adoc` currently has JSON handler casing/name drift (`jsonhandler`/`Jsonhandler` vs `jsonHandler`/`JsonHandler`).
+- Reference documentation now uses Antora pages under `src/main/antora/modules/ROOT/pages/`; keep `nav.adoc`, pages, and docs build commands aligned.

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
 
     <groupId>io.vanslog</groupId>
     <artifactId>spring-data-meilisearch</artifactId>
-    <version>0.7.4-SNAPSHOT</version>
+    <version>0.8.0</version>
 
     <parent>
         <groupId>org.springframework.data.build</groupId>
         <artifactId>spring-data-parent</artifactId>
-        <version>3.3.13-SNAPSHOT</version>
+        <version>3.3.13</version>
     </parent>
 
     <name>Spring Data Meilisearch</name>
@@ -25,7 +25,7 @@
     </organization>
 
     <properties>
-        <springdata.commons>3.3.13-SNAPSHOT</springdata.commons>
+        <springdata.commons>3.3.13</springdata.commons>
         <meilisearch-java>0.20.1</meilisearch-java>
         <okhttp>5.3.2</okhttp>
         <testcontainers-meilisearch>1.0.5</testcontainers-meilisearch>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <springdata.commons>3.3.13</springdata.commons>
         <meilisearch-java>0.20.1</meilisearch-java>
         <okhttp>5.3.2</okhttp>
+        <kotlin-stdlib>2.2.21</kotlin-stdlib>
         <testcontainers-meilisearch>1.0.5</testcontainers-meilisearch>
 
         <java-module-name>spring.data.meilisearch</java-module-name>
@@ -71,6 +72,11 @@
             <artifactId>okhttp-jvm</artifactId>
             <version>${okhttp}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin-stdlib}</version>
+        </dependency>
 
         <!-- Jackson JSON Mapper -->
         <dependency>
@@ -108,6 +114,7 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>3.2.0</version>
             </plugin>
         </plugins>
     </build>
@@ -166,7 +173,7 @@
                             </checkstyleRules>
                             <includes>**/*</includes>
                             <excludes>
-                                .git/**/*,target/**/*,**/target/**/*,.idea/**/*,**/spring.schemas,**/*.svg,mvnw,mvnw.cmd,**/*.policy,
+                                .git/**/*,target/**/*,**/target/**/*,node_modules/**/*,**/node_modules/**/*,.idea/**/*,**/spring.schemas,**/*.svg,mvnw,mvnw.cmd,**/*.policy,
                                 **/spring.handlers,**/namespace.xml,**/*.xsd,pom.xml,**/*.adoc
                             </excludes>
                             <sourceDirectories>./</sourceDirectories>


### PR DESCRIPTION
## Summary
- Prepare the `0.8.0` release by removing snapshot versions from the project and Spring Data dependencies.
- Update the agent guide for the Antora documentation layout.
- Stabilize release build dependencies by aligning Kotlin stdlib with OkHttp 5.3.2, pinning the Asciidoctor Maven plugin version, and excluding generated `node_modules` from no-http checks.

## Verification
- `./mvnw dependency:tree -Dverbose -Dscope=compile -Dincludes=org.jetbrains.kotlin:kotlin-stdlib,com.squareup.okhttp3:okhttp-jvm,com.squareup.okio:okio-jvm`
- `./mvnw -Pantora antora:antora`
- `./mvnw verify -Pci`

Related Issue: N/A - release preparation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation build and guidance to reflect new Antora-based structure and build commands.

* **Chores**
  * Released version 0.8.0.
  * Updated parent framework dependency and build tooling versions.
  * Added Kotlin standard library dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->