### PR TITLE
Use search response totals for repository pages.

### DIFF
--- a/src/main/antora/modules/ROOT/pages/meilisearch-operations.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch-operations.adoc
@@ -77,13 +77,13 @@ Contains the following information:
 * An unmodifiable list of `SearchHit<T>` objects
 * Total hit metadata through `getTotalHits()` and `getTotalHitsRelation()`
 ** `EQUAL_TO`: `getTotalHits()` is equal to the total matching result set reported by the search engine.
-** `GREATER_THAN_OR_EQUAL_TO`: `getTotalHits()` is a lower bound; the actual matching result set may be higher.
-** `OFF`: total hit metadata is unavailable, so `getTotalHits()` falls back to the loaded hit count.
+** `OFF`: exact total-hit metadata is unavailable, so `getTotalHits()` is the loaded hit count and is not usable as a page total.
 * Execution duration
 * Methods to access individual search hits and check if results exist
 
 The number of returned hits is separate from the reported total hits.
-Use `getSearchHits().size()` for the current result content and `getTotalHits()` together with `getTotalHitsRelation()` for the search total metadata.
+Use `getSearchHits().size()` for the current result content and use `getTotalHits()` as exact search total metadata only when `getTotalHitsRelation()` is `EQUAL_TO`.
+Meilisearch exposes this exact total through paginated search responses; estimated totals and flattened or aggregate responses are reported with `OFF`.
 
 [[meilisearch.operations.queries]]
 == Queries

--- a/src/main/antora/modules/ROOT/pages/meilisearch-operations.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch-operations.adoc
@@ -75,8 +75,12 @@ Contains the following information:
 Contains the following information:
 
 * An unmodifiable list of `SearchHit<T>` objects
+* Total hit metadata through `getTotalHits()` and `getTotalHitsRelation()`
 * Execution duration
 * Methods to access individual search hits and check if results exist
+
+The number of returned hits is separate from the reported total hits.
+Use `getSearchHits().size()` for the current result content and `getTotalHits()` together with `getTotalHitsRelation()` for the search total metadata.
 
 [[meilisearch.operations.queries]]
 == Queries

--- a/src/main/antora/modules/ROOT/pages/meilisearch-operations.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch-operations.adoc
@@ -76,6 +76,9 @@ Contains the following information:
 
 * An unmodifiable list of `SearchHit<T>` objects
 * Total hit metadata through `getTotalHits()` and `getTotalHitsRelation()`
+** `EQUAL_TO`: `getTotalHits()` is equal to the total matching result set reported by the search engine.
+** `GREATER_THAN_OR_EQUAL_TO`: `getTotalHits()` is a lower bound; the actual matching result set may be higher.
+** `OFF`: total hit metadata is unavailable, so `getTotalHits()` falls back to the loaded hit count.
 * Execution duration
 * Methods to access individual search hits and check if results exist
 

--- a/src/main/antora/modules/ROOT/pages/meilisearch-repositories.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch-repositories.adoc
@@ -56,6 +56,10 @@ Note that the above methods perform different behaviors.
 The `findById` and `findAllById` methods use the https://www.meilisearch.com/docs/reference/api/documents#get-one-document[Get one document] or https://www.meilisearch.com/docs/reference/api/documents#get-documents-with-post[Get documents] API.
 However, the `findAll` method uses the https://www.meilisearch.com/docs/reference/api/search[Search] API.
 
+For `findAll(Pageable pageable)`, the returned `Page` total elements are based on the total reported by the Meilisearch Search API response when available.
+They are not derived from a separate repository `count()` call.
+The number of elements in the page content remains the number of hits returned for the requested page.
+
 IMPORTANT: This difference in behavior can also cause results to show differently.
 For example, `displayedAttributes` in xref:meilisearch-settings.adoc[Meilisearch Settings] does not work with the Get one document or Get documents API.
 Go to https://www.meilisearch.com/docs/reference/api/settings#displayed-attributes[Meilisearch documentation] for more information.

--- a/src/main/antora/modules/ROOT/pages/meilisearch-repositories.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch-repositories.adoc
@@ -57,7 +57,7 @@ The `findById` and `findAllById` methods use the https://www.meilisearch.com/doc
 However, the `findAll` method uses the https://www.meilisearch.com/docs/reference/api/search[Search] API.
 
 For `findAll(Pageable pageable)`, the returned `Page` total elements are based on the total reported by the Meilisearch Search API response when available.
-They are not derived from a separate repository `count()` call.
+If the search response does not expose total-hit metadata, the repository falls back to `count()`.
 The number of elements in the page content remains the number of hits returned for the requested page.
 
 IMPORTANT: This difference in behavior can also cause results to show differently.

--- a/src/main/antora/modules/ROOT/pages/meilisearch-repositories.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch-repositories.adoc
@@ -56,9 +56,10 @@ Note that the above methods perform different behaviors.
 The `findById` and `findAllById` methods use the https://www.meilisearch.com/docs/reference/api/documents#get-one-document[Get one document] or https://www.meilisearch.com/docs/reference/api/documents#get-documents-with-post[Get documents] API.
 However, the `findAll` method uses the https://www.meilisearch.com/docs/reference/api/search[Search] API.
 
-For `findAll(Pageable pageable)`, the returned `Page` total elements are based on the total reported by the Meilisearch Search API response when available.
-If the search response does not expose total-hit metadata, the repository falls back to `count()`.
+For `findAll(Pageable pageable)`, the returned `Page` total elements come from Meilisearch paginated search `totalHits`.
+The repository does not use estimated totals or a separate `count()` query for page totals.
 The number of elements in the page content remains the number of hits returned for the requested page.
+If the entity configures `@Pagination(maxTotalHits = ...)`, Meilisearch can cap the reported `totalHits`, and the repository `Page` total reflects that capped value.
 
 IMPORTANT: This difference in behavior can also cause results to show differently.
 For example, `displayedAttributes` in xref:meilisearch-settings.adoc[Meilisearch Settings] does not work with the Get one document or Get documents API.

--- a/src/main/antora/modules/ROOT/pages/meilisearch-settings.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch-settings.adoc
@@ -337,6 +337,6 @@ class Product {
 <.> The `maxTotalHits` is used to define the maximum number of results that can be reached through search.
 
 See the https://www.meilisearch.com/docs/capabilities/full_text_search/how_to/paginate_search_results[Meilisearch pagination documentation] for details on `maxTotalHits`, `estimatedTotalHits`, and `totalHits`.
-This setting can also cap the total hits reported by Meilisearch search responses.
-As a result, total hit metadata such as `SearchHits#getTotalHits()` and repository `Page` totals can reflect the capped search total, while the page content size still reflects only the hits returned for the current request.
+This setting can cap the `totalHits` reported by Meilisearch paginated search responses.
+As a result, exact total hit metadata such as `SearchHits#getTotalHits()` with relation `EQUAL_TO` and repository `Page` totals can reflect the capped search total, while the page content size still reflects only the hits returned for the current request.
 ====

--- a/src/main/antora/modules/ROOT/pages/meilisearch-settings.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch-settings.adoc
@@ -334,5 +334,8 @@ class Product {
 }
 ----
 
-<.> The `maxTotalHits` is used to define the maximum number of results that can be returned by the search engine.
+<.> The `maxTotalHits` is used to define the maximum number of results that can be reached through search.
+
+This setting can also cap the total hits reported by Meilisearch search responses.
+As a result, total hit metadata such as `SearchHits#getTotalHits()` and repository `Page` totals can reflect the capped search total, while the page content size still reflects only the hits returned for the current request.
 ====

--- a/src/main/antora/modules/ROOT/pages/meilisearch-settings.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch-settings.adoc
@@ -336,6 +336,7 @@ class Product {
 
 <.> The `maxTotalHits` is used to define the maximum number of results that can be reached through search.
 
+See the https://www.meilisearch.com/docs/capabilities/full_text_search/how_to/paginate_search_results[Meilisearch pagination documentation] for details on `maxTotalHits`, `estimatedTotalHits`, and `totalHits`.
 This setting can also cap the total hits reported by Meilisearch search responses.
 As a result, total hit metadata such as `SearchHits#getTotalHits()` and repository `Page` totals can reflect the capped search total, while the page content size still reflects only the hits returned for the current request.
 ====

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverter.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meilisearch.sdk.model.FacetSearchable;
 import com.meilisearch.sdk.model.MultiSearchResult;
 import com.meilisearch.sdk.model.Results;
-import com.meilisearch.sdk.model.SearchResult;
 import com.meilisearch.sdk.model.SearchResultPaginated;
 import com.meilisearch.sdk.model.Searchable;
 import com.meilisearch.sdk.model.SimilarDocumentsResults;
@@ -67,12 +66,7 @@ public class ResponseConverter {
 		if (searchable instanceof SearchResultPaginated) {
 			SearchResultPaginated result = (SearchResultPaginated) searchable;
 			return new SearchHitsImpl<>(executionDuration, searchHits, result.getTotalHits(),
-					TotalHitsRelation.GREATER_THAN_OR_EQUAL_TO);
-		}
-		if (searchable instanceof SearchResult) {
-			SearchResult result = (SearchResult) searchable;
-			return new SearchHitsImpl<>(executionDuration, searchHits, result.getEstimatedTotalHits(),
-					TotalHitsRelation.ESTIMATED);
+					TotalHitsRelation.EQUAL_TO);
 		}
 		return new SearchHitsImpl<>(executionDuration, searchHits);
 	}
@@ -92,8 +86,7 @@ public class ResponseConverter {
 				}).toList();
 
 		Duration executionDuration = Duration.ofMillis(result.getProcessingTimeMs());
-		return new SearchHitsImpl<>(executionDuration, searchHits, result.getEstimatedTotalHits(),
-				TotalHitsRelation.ESTIMATED);
+		return new SearchHitsImpl<>(executionDuration, searchHits);
 	}
 
 	public <T> SearchHits<T> mapResult(SimilarDocumentsResults result, Class<T> clazz) {
@@ -103,8 +96,7 @@ public class ResponseConverter {
 				.toList();
 
 		Duration executionDuration = Duration.ofMillis(result.getProcessingTimeMs());
-		return new SearchHitsImpl<>(executionDuration, searchHits, result.getEstimatedTotalHits(),
-				TotalHitsRelation.ESTIMATED);
+		return new SearchHitsImpl<>(executionDuration, searchHits);
 	}
 
 	public <T> SearchHits<T> mapResults(Results<MultiSearchResult> results, Class<T> clazz) {

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverter.java
@@ -18,6 +18,7 @@ package io.vanslog.spring.data.meilisearch.client.msc;
 import io.vanslog.spring.data.meilisearch.core.SearchHit;
 import io.vanslog.spring.data.meilisearch.core.SearchHits;
 import io.vanslog.spring.data.meilisearch.core.SearchHitsImpl;
+import io.vanslog.spring.data.meilisearch.core.TotalHitsRelation;
 import io.vanslog.spring.data.meilisearch.core.federation.FederationResponse;
 
 import java.time.Duration;
@@ -28,6 +29,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meilisearch.sdk.model.FacetSearchable;
 import com.meilisearch.sdk.model.MultiSearchResult;
 import com.meilisearch.sdk.model.Results;
+import com.meilisearch.sdk.model.SearchResult;
+import com.meilisearch.sdk.model.SearchResultPaginated;
 import com.meilisearch.sdk.model.Searchable;
 import com.meilisearch.sdk.model.SimilarDocumentsResults;
 
@@ -61,6 +64,16 @@ public class ResponseConverter {
 	public <T> SearchHits<T> mapHits(Searchable searchable, Class<T> clazz) {
 		List<SearchHit<T>> searchHits = this.mapHitList(searchable, clazz);
 		Duration executionDuration = Duration.ofMillis(searchable.getProcessingTimeMs());
+		if (searchable instanceof SearchResultPaginated) {
+			SearchResultPaginated result = (SearchResultPaginated) searchable;
+			return new SearchHitsImpl<>(executionDuration, searchHits, result.getTotalHits(),
+					TotalHitsRelation.GREATER_THAN_OR_EQUAL_TO);
+		}
+		if (searchable instanceof SearchResult) {
+			SearchResult result = (SearchResult) searchable;
+			return new SearchHitsImpl<>(executionDuration, searchHits, result.getEstimatedTotalHits(),
+					TotalHitsRelation.ESTIMATED);
+		}
 		return new SearchHitsImpl<>(executionDuration, searchHits);
 	}
 
@@ -79,7 +92,8 @@ public class ResponseConverter {
 				}).toList();
 
 		Duration executionDuration = Duration.ofMillis(result.getProcessingTimeMs());
-		return new SearchHitsImpl<>(executionDuration, searchHits);
+		return new SearchHitsImpl<>(executionDuration, searchHits, result.getEstimatedTotalHits(),
+				TotalHitsRelation.ESTIMATED);
 	}
 
 	public <T> SearchHits<T> mapResult(SimilarDocumentsResults result, Class<T> clazz) {
@@ -89,7 +103,8 @@ public class ResponseConverter {
 				.toList();
 
 		Duration executionDuration = Duration.ofMillis(result.getProcessingTimeMs());
-		return new SearchHitsImpl<>(executionDuration, searchHits);
+		return new SearchHitsImpl<>(executionDuration, searchHits, result.getEstimatedTotalHits(),
+				TotalHitsRelation.ESTIMATED);
 	}
 
 	public <T> SearchHits<T> mapResults(Results<MultiSearchResult> results, Class<T> clazz) {

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/SearchHits.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/SearchHits.java
@@ -48,14 +48,16 @@ public interface SearchHits<T> extends Streamable<SearchHit<T>> {
 	List<SearchHit<T>> getSearchHits();
 
 	/**
-	 * @return the total hits returned by the search response, or the loaded hit count if unavailable.
+	 * @return the exact total matching result set only when {@link #getTotalHitsRelation()} is
+	 *         {@link TotalHitsRelation#EQUAL_TO}; otherwise the loaded hit count, which is not usable as a page total.
 	 */
 	default long getTotalHits() {
 		return getSearchHits().size();
 	}
 
 	/**
-	 * @return how {@link #getTotalHits()} relates to the total matching result set.
+	 * @return how {@link #getTotalHits()} relates to the total matching result set. Only
+	 *         {@link TotalHitsRelation#EQUAL_TO} represents exact total-hit metadata.
 	 */
 	default TotalHitsRelation getTotalHitsRelation() {
 		return TotalHitsRelation.OFF;

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/SearchHits.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/SearchHits.java
@@ -47,6 +47,20 @@ public interface SearchHits<T> extends Streamable<SearchHit<T>> {
 	 */
 	List<SearchHit<T>> getSearchHits();
 
+	/**
+	 * @return the total hits returned by the search response, or the loaded hit count if unavailable.
+	 */
+	default long getTotalHits() {
+		return getSearchHits().size();
+	}
+
+	/**
+	 * @return how {@link #getTotalHits()} relates to the total matching result set.
+	 */
+	default TotalHitsRelation getTotalHitsRelation() {
+		return TotalHitsRelation.OFF;
+	}
+
 	@Override
 	default Iterator<SearchHit<T>> iterator() {
 		return getSearchHits().iterator();

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/SearchHits.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/SearchHits.java
@@ -48,7 +48,7 @@ public interface SearchHits<T> extends Streamable<SearchHit<T>> {
 	List<SearchHit<T>> getSearchHits();
 
 	/**
-	 * @return the exact total matching result set only when {@link #getTotalHitsRelation()} is
+	 * @return the reported total-hit metadata only when {@link #getTotalHitsRelation()} is
 	 *         {@link TotalHitsRelation#EQUAL_TO}; otherwise the loaded hit count, which is not usable as a page total.
 	 */
 	default long getTotalHits() {
@@ -56,8 +56,8 @@ public interface SearchHits<T> extends Streamable<SearchHit<T>> {
 	}
 
 	/**
-	 * @return how {@link #getTotalHits()} relates to the total matching result set. Only
-	 *         {@link TotalHitsRelation#EQUAL_TO} represents exact total-hit metadata.
+	 * @return how {@link #getTotalHits()} relates to the reported total-hit metadata. Only
+	 *         {@link TotalHitsRelation#EQUAL_TO} marks total-hit metadata reported by the search response.
 	 */
 	default TotalHitsRelation getTotalHitsRelation() {
 		return TotalHitsRelation.OFF;

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/SearchHitsImpl.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/SearchHitsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/SearchHitsImpl.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/SearchHitsImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vanslog.spring.data.meilisearch.core;
 
 import java.time.Duration;

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/SearchHitsImpl.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/SearchHitsImpl.java
@@ -10,11 +10,20 @@ public class SearchHitsImpl<T> implements SearchHits<T> {
 
 	private final Duration executionDuration;
 	private final List<? extends SearchHit<T>> searchHits;
+	private final long totalHits;
+	private final TotalHitsRelation totalHitsRelation;
 	private final Lazy<List<SearchHit<T>>> unmodifiableSearchHits;
 
 	public SearchHitsImpl(Duration executionDuration, List<? extends SearchHit<T>> searchHits) {
+		this(executionDuration, searchHits, searchHits.size(), TotalHitsRelation.OFF);
+	}
+
+	public SearchHitsImpl(Duration executionDuration, List<? extends SearchHit<T>> searchHits, long totalHits,
+			TotalHitsRelation totalHitsRelation) {
 		this.executionDuration = executionDuration;
 		this.searchHits = searchHits;
+		this.totalHits = totalHits;
+		this.totalHitsRelation = totalHitsRelation;
 		this.unmodifiableSearchHits = Lazy.of(() -> Collections.unmodifiableList(searchHits));
 	}
 
@@ -34,10 +43,22 @@ public class SearchHitsImpl<T> implements SearchHits<T> {
 	}
 
 	@Override
+	public long getTotalHits() {
+		return totalHits;
+	}
+
+	@Override
+	public TotalHitsRelation getTotalHitsRelation() {
+		return totalHitsRelation;
+	}
+
+	@Override
 	public String toString() {
 		return "SearchHits{" + //
 				"executionDuration=" + executionDuration + //
 				", searchHits={" + searchHits.size() + " elements}" + //
+				", totalHits=" + totalHits + //
+				", totalHitsRelation=" + totalHitsRelation + //
 				'}';
 	}
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/TotalHitsRelation.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/TotalHitsRelation.java
@@ -26,11 +26,6 @@ public enum TotalHitsRelation {
 	EQUAL_TO,
 
 	/**
-	 * The total hit count is a lower bound for the total matching result set.
-	 */
-	GREATER_THAN_OR_EQUAL_TO,
-
-	/**
 	 * Total hit metadata is unavailable.
 	 */
 	OFF

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/TotalHitsRelation.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/TotalHitsRelation.java
@@ -15,10 +15,23 @@
  */
 package io.vanslog.spring.data.meilisearch.core;
 
+/**
+ * Relation that describes how {@link SearchHits#getTotalHits()} relates to the total matching result set.
+ */
 public enum TotalHitsRelation {
 
+	/**
+	 * The total hit count is equal to the total matching result set reported by the search engine.
+	 */
 	EQUAL_TO,
+
+	/**
+	 * The total hit count is a lower bound for the total matching result set.
+	 */
 	GREATER_THAN_OR_EQUAL_TO,
-	ESTIMATED,
+
+	/**
+	 * Total hit metadata is unavailable.
+	 */
 	OFF
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/TotalHitsRelation.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/TotalHitsRelation.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.core;
+
+public enum TotalHitsRelation {
+
+	EQUAL_TO,
+	GREATER_THAN_OR_EQUAL_TO,
+	ESTIMATED,
+	OFF
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/repository/support/SimpleMeilisearchRepository.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/repository/support/SimpleMeilisearchRepository.java
@@ -20,7 +20,6 @@ import io.vanslog.spring.data.meilisearch.core.SearchHit;
 import io.vanslog.spring.data.meilisearch.core.SearchHitSupport;
 import io.vanslog.spring.data.meilisearch.core.SearchHits;
 import io.vanslog.spring.data.meilisearch.core.SearchPage;
-import io.vanslog.spring.data.meilisearch.core.TotalHitsRelation;
 import io.vanslog.spring.data.meilisearch.core.query.BaseQuery;
 import io.vanslog.spring.data.meilisearch.core.query.BasicQuery;
 import io.vanslog.spring.data.meilisearch.repository.MeilisearchRepository;
@@ -169,9 +168,7 @@ public class SimpleMeilisearchRepository<T, ID> implements MeilisearchRepository
 		Assert.notNull(pageable, "pageable must not be null");
 		BaseQuery query = BasicQuery.builder().withPageable(pageable).build();
 		SearchHits<T> searchHits = meilisearchOperations.search(query, entityType);
-		long total = searchHits.getTotalHitsRelation() != TotalHitsRelation.OFF ? searchHits.getTotalHits()
-				: this.count();
-		SearchPage<T> page = SearchHitSupport.searchPageFor(searchHits, query.getPageable(), total);
+		SearchPage<T> page = SearchHitSupport.searchPageFor(searchHits, query.getPageable(), searchHits.getTotalHits());
 		// noinspection ConstantConditions
 		return (Page<T>) SearchHitSupport.unwrapSearchHits(page);
 	}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/repository/support/SimpleMeilisearchRepository.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/repository/support/SimpleMeilisearchRepository.java
@@ -20,6 +20,7 @@ import io.vanslog.spring.data.meilisearch.core.SearchHit;
 import io.vanslog.spring.data.meilisearch.core.SearchHitSupport;
 import io.vanslog.spring.data.meilisearch.core.SearchHits;
 import io.vanslog.spring.data.meilisearch.core.SearchPage;
+import io.vanslog.spring.data.meilisearch.core.TotalHitsRelation;
 import io.vanslog.spring.data.meilisearch.core.query.BaseQuery;
 import io.vanslog.spring.data.meilisearch.core.query.BasicQuery;
 import io.vanslog.spring.data.meilisearch.repository.MeilisearchRepository;
@@ -168,7 +169,9 @@ public class SimpleMeilisearchRepository<T, ID> implements MeilisearchRepository
 		Assert.notNull(pageable, "pageable must not be null");
 		BaseQuery query = BasicQuery.builder().withPageable(pageable).build();
 		SearchHits<T> searchHits = meilisearchOperations.search(query, entityType);
-		SearchPage<T> page = SearchHitSupport.searchPageFor(searchHits, query.getPageable(), this.count());
+		long total = searchHits.getTotalHitsRelation() != TotalHitsRelation.OFF ? searchHits.getTotalHits()
+				: this.count();
+		SearchPage<T> page = SearchHitSupport.searchPageFor(searchHits, query.getPageable(), total);
 		// noinspection ConstantConditions
 		return (Page<T>) SearchHitSupport.unwrapSearchHits(page);
 	}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverterUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverterUnitTests.java
@@ -19,14 +19,20 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.meilisearch.sdk.model.MultiSearchResult;
+import com.meilisearch.sdk.model.Results;
+import com.meilisearch.sdk.model.SearchResult;
+import com.meilisearch.sdk.model.SearchResultPaginated;
 import com.meilisearch.sdk.model.SimilarDocumentsResults;
 
 import io.vanslog.spring.data.meilisearch.core.SearchHit;
 import io.vanslog.spring.data.meilisearch.core.SearchHits;
+import io.vanslog.spring.data.meilisearch.core.TotalHitsRelation;
 
 /**
  * Unit tests for {@link ResponseConverter}.
@@ -38,26 +44,88 @@ class ResponseConverterUnitTests {
 	private final ResponseConverter converter = new ResponseConverter();
 
 	@Test
-	void shouldConvertSimilarDocumentsResultsToSearchHits() {
-		SimilarDocumentsResults result = new SimilarDocumentsResults();
+	void shouldConvertPaginatedTotalHitsMetadataToSearchHits() {
+		SearchResultPaginated result = new SearchResultPaginated();
 		ArrayList<HashMap<String, Object>> hits = new ArrayList<>();
-		HashMap<String, Object> hit = new HashMap<>();
-		hit.put("id", "143");
-		hit.put("title", "Escape Room");
-		hits.add(hit);
+		hits.add(hit("143", "Escape Room"));
+		hits.add(hit("144", "Carol"));
 
 		ReflectionTestUtils.setField(result, "hits", hits);
 		ReflectionTestUtils.setField(result, "processingTimeMs", 25);
+		ReflectionTestUtils.setField(result, "totalHits", 10);
+
+		SearchHits<SimilarMovie> searchHits = converter.mapHits(result, SimilarMovie.class);
+
+		assertThat(searchHits.getSearchHits()).hasSize(2);
+		assertThat(searchHits.getTotalHits()).isEqualTo(10);
+		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.GREATER_THAN_OR_EQUAL_TO);
+	}
+
+	@Test
+	void shouldConvertEstimatedTotalHitsMetadataToSearchHits() {
+		SearchResult result = new SearchResult();
+		ArrayList<HashMap<String, Object>> hits = new ArrayList<>();
+		hits.add(hit("143", "Escape Room"));
+
+		ReflectionTestUtils.setField(result, "hits", hits);
+		ReflectionTestUtils.setField(result, "processingTimeMs", 25);
+		ReflectionTestUtils.setField(result, "estimatedTotalHits", 15);
+
+		SearchHits<SimilarMovie> searchHits = converter.mapHits(result, SimilarMovie.class);
+
+		assertThat(searchHits.getSearchHits()).hasSize(1);
+		assertThat(searchHits.getTotalHits()).isEqualTo(15);
+		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.ESTIMATED);
+	}
+
+	@Test
+	void shouldConvertSimilarDocumentsResultsToSearchHits() {
+		SimilarDocumentsResults result = new SimilarDocumentsResults();
+		ArrayList<HashMap<String, Object>> hits = new ArrayList<>();
+		hits.add(hit("143", "Escape Room"));
+
+		ReflectionTestUtils.setField(result, "hits", hits);
+		ReflectionTestUtils.setField(result, "processingTimeMs", 25);
+		ReflectionTestUtils.setField(result, "estimatedTotalHits", 15);
 
 		SearchHits<SimilarMovie> searchHits = converter.mapResult(result, SimilarMovie.class);
 
 		assertThat(searchHits.getExecutionDuration().toMillis()).isEqualTo(25);
 		assertThat(searchHits.getSearchHits()).hasSize(1);
+		assertThat(searchHits.getTotalHits()).isEqualTo(15);
+		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.ESTIMATED);
 		SearchHit<SimilarMovie> searchHit = searchHits.getSearchHit(0);
 		assertThat(searchHit.getProcessingTimeMs()).isEqualTo(25);
 		assertThat(searchHit.getQuery()).isEmpty();
 		assertThat(searchHit.getContent().getId()).isEqualTo("143");
 		assertThat(searchHit.getContent().getTitle()).isEqualTo("Escape Room");
+	}
+
+	@Test
+	void shouldKeepTotalHitsOffForFlattenedMultiSearchResults() {
+		MultiSearchResult result1 = new MultiSearchResult();
+		ReflectionTestUtils.setField(result1, "hits", new ArrayList<>(List.of(hit("143", "Escape Room"))));
+		ReflectionTestUtils.setField(result1, "processingTimeMs", 25);
+
+		MultiSearchResult result2 = new MultiSearchResult();
+		ReflectionTestUtils.setField(result2, "hits", new ArrayList<>(List.of(hit("144", "Carol"))));
+		ReflectionTestUtils.setField(result2, "processingTimeMs", 15);
+
+		Results<MultiSearchResult> results = new Results<>();
+		ReflectionTestUtils.setField(results, "results", new MultiSearchResult[] { result1, result2 });
+
+		SearchHits<SimilarMovie> searchHits = converter.mapResults(results, SimilarMovie.class);
+
+		assertThat(searchHits.getSearchHits()).hasSize(2);
+		assertThat(searchHits.getTotalHits()).isEqualTo(2);
+		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.OFF);
+	}
+
+	private static HashMap<String, Object> hit(String id, String title) {
+		HashMap<String, Object> hit = new HashMap<>();
+		hit.put("id", id);
+		hit.put("title", title);
+		return hit;
 	}
 
 	static class SimilarMovie {

--- a/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverterUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverterUnitTests.java
@@ -58,11 +58,11 @@ class ResponseConverterUnitTests {
 
 		assertThat(searchHits.getSearchHits()).hasSize(2);
 		assertThat(searchHits.getTotalHits()).isEqualTo(10);
-		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.GREATER_THAN_OR_EQUAL_TO);
+		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.EQUAL_TO);
 	}
 
 	@Test
-	void shouldConvertEstimatedTotalHitsMetadataToSearchHits() {
+	void shouldKeepTotalHitsOffForEstimatedSearchResults() {
 		SearchResult result = new SearchResult();
 		ArrayList<HashMap<String, Object>> hits = new ArrayList<>();
 		hits.add(hit("143", "Escape Room"));
@@ -74,8 +74,8 @@ class ResponseConverterUnitTests {
 		SearchHits<SimilarMovie> searchHits = converter.mapHits(result, SimilarMovie.class);
 
 		assertThat(searchHits.getSearchHits()).hasSize(1);
-		assertThat(searchHits.getTotalHits()).isEqualTo(15);
-		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.ESTIMATED);
+		assertThat(searchHits.getTotalHits()).isEqualTo(1);
+		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.OFF);
 	}
 
 	@Test
@@ -92,8 +92,8 @@ class ResponseConverterUnitTests {
 
 		assertThat(searchHits.getExecutionDuration().toMillis()).isEqualTo(25);
 		assertThat(searchHits.getSearchHits()).hasSize(1);
-		assertThat(searchHits.getTotalHits()).isEqualTo(15);
-		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.ESTIMATED);
+		assertThat(searchHits.getTotalHits()).isEqualTo(1);
+		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.OFF);
 		SearchHit<SimilarMovie> searchHit = searchHits.getSearchHit(0);
 		assertThat(searchHit.getProcessingTimeMs()).isEqualTo(25);
 		assertThat(searchHit.getQuery()).isEmpty();

--- a/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverterUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverterUnitTests.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.meilisearch.sdk.model.FacetSearchable;
 import com.meilisearch.sdk.model.MultiSearchResult;
 import com.meilisearch.sdk.model.Results;
 import com.meilisearch.sdk.model.SearchResult;
@@ -118,6 +119,32 @@ class ResponseConverterUnitTests {
 
 		assertThat(searchHits.getSearchHits()).hasSize(2);
 		assertThat(searchHits.getTotalHits()).isEqualTo(2);
+		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.OFF);
+	}
+
+	@Test
+	void shouldKeepTotalHitsOffForFacetSearchResults() {
+		FacetSearchable result = new FacetSearchable() {
+			@Override
+			public ArrayList<HashMap<String, Object>> getFacetHits() {
+				return new ArrayList<>(List.of(hit("143", "Escape Room")));
+			}
+
+			@Override
+			public int getProcessingTimeMs() {
+				return 25;
+			}
+
+			@Override
+			public String getFacetQuery() {
+				return "Escape";
+			}
+		};
+
+		SearchHits<SimilarMovie> searchHits = converter.mapHits(result, SimilarMovie.class);
+
+		assertThat(searchHits.getSearchHits()).hasSize(1);
+		assertThat(searchHits.getTotalHits()).isEqualTo(1);
 		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.OFF);
 	}
 

--- a/src/test/java/io/vanslog/spring/data/meilisearch/repository/MeilisearchRepositoryIntegrationTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/repository/MeilisearchRepositoryIntegrationTests.java
@@ -317,7 +317,7 @@ class MeilisearchRepositoryIntegrationTests {
 		Page<TotalHitsLimited> page = totalHitsLimitedRepository.findAll(PageRequest.of(0, elementCount));
 
 		// then
-		assertThat(page).hasSizeLessThan(elementCount);
+		assertThat(page).hasSize(10);
 		assertThat(page.getTotalElements()).isEqualTo(10);
 		assertThat(page.getTotalPages()).isEqualTo(1);
 	}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/repository/MeilisearchRepositoryIntegrationTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/repository/MeilisearchRepositoryIntegrationTests.java
@@ -258,7 +258,7 @@ class MeilisearchRepositoryIntegrationTests {
 	}
 
 	@Test
-	void shouldFindDocumentsWithPaging() {
+	void shouldFindDocumentsWithPagingAndUseSearchTotalHitsAsPageTotal() {
 		// given
 		int pagingSize = 2;
 
@@ -292,6 +292,7 @@ class MeilisearchRepositoryIntegrationTests {
 
 		// then
 		assertThat(page1.getTotalElements()).isEqualTo(movies.size());
+		assertThat(page2.getTotalElements()).isEqualTo(movies.size());
 
 		assertThat(page1.getContent()).hasSize(2);
 		assertThat(page1.getContent().get(0)).isEqualTo(movie1);
@@ -302,7 +303,7 @@ class MeilisearchRepositoryIntegrationTests {
 	}
 
 	@Test
-	void shouldNotSearchAllElementsWhenMaxTotalHitsAre10() {
+	void shouldUseMaxTotalHitsCapAsRepositoryPageTotal() {
 		// given
 		int elementCount = 11;
 
@@ -317,6 +318,7 @@ class MeilisearchRepositoryIntegrationTests {
 		Page<TotalHitsLimited> page = totalHitsLimitedRepository.findAll(PageRequest.of(0, elementCount));
 
 		// then
+		assertThat(totalHitsLimitedRepository.count()).isEqualTo(elementCount);
 		assertThat(page).hasSize(10);
 		assertThat(page.getTotalElements()).isEqualTo(10);
 		assertThat(page.getTotalPages()).isEqualTo(1);

--- a/src/test/java/io/vanslog/spring/data/meilisearch/repository/MeilisearchRepositoryIntegrationTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/repository/MeilisearchRepositoryIntegrationTests.java
@@ -50,6 +50,7 @@ class MeilisearchRepositoryIntegrationTests {
 	@BeforeEach
 	void setUp() {
 		movieRepository.deleteAll();
+		totalHitsLimitedRepository.deleteAll();
 	}
 
 	@Test
@@ -317,6 +318,8 @@ class MeilisearchRepositoryIntegrationTests {
 
 		// then
 		assertThat(page).hasSizeLessThan(elementCount);
+		assertThat(page.getTotalElements()).isEqualTo(10);
+		assertThat(page.getTotalPages()).isEqualTo(1);
 	}
 
 	interface MovieRepository extends MeilisearchRepository<Movie, Integer> {}


### PR DESCRIPTION
## Summary
- Expose total hit metadata on `SearchHits` and preserve Meilisearch response totals during conversion.
- Use search response totals for repository `findAll(Pageable)` page totals instead of a separate document `count()` when totals are available.
- Document the distinction between returned hits, total hits, and `maxTotalHits`-capped search totals.

## Verification
- `./mvnw -Dtest=ResponseConverterUnitTests,MeilisearchRepositoryIntegrationTests#shouldFindDocumentsWithPaging,MeilisearchRepositoryIntegrationTests#shouldNotSearchAllElementsWhenMaxTotalHitsAre10 test`
- `./mvnw -Pantora antora:antora`

Closes #167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results now include explicit total-hits metadata and a relation indicator (exact, estimated, or unavailable).
  * Repository paging now uses search-reported totals for Page totals and respects configured max-total-hits caps.

* **Documentation**
  * Expanded docs on accessing total-hit metadata, execution duration, per-hit access, and pagination behavior/limits.

* **Tests**
  * Added and updated tests verifying total-hits mapping, relation semantics, paging totals, and max-total-hits capping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->