### PR TITLE
Improve reference documentation versioning.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,15 +18,6 @@ on:
         description: 'Git ref to checkout (leave empty for current branch)'
         required: false
         default: ''
-      path:
-        description: 'Destination path, such as 1.0.0 or snapshot (leave empty for root)'
-        required: false
-        default: ''
-      update-root:
-        description: 'Also update / with this documentation build'
-        required: false
-        type: boolean
-        default: false
 
 concurrency:
   group: pages
@@ -43,14 +34,27 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: ${{ github.event_name == 'pull_request' && 1 || 0 }}
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
-      - name: Build reference documentation
+      - name: Build PR preview documentation
+        if: github.event_name == 'pull_request'
         run: ./mvnw -Pantora antora:antora
+
+      - name: Prepare Antora CLI for publish documentation
+        if: github.event_name != 'pull_request'
+        run: ./mvnw -Pantora antora:antora
+
+      - name: Build publish documentation
+        if: github.event_name != 'pull_request'
+        run: |
+          rm -rf target/site
+          npx --offline antora --to-dir target/site antora-playbook.yml
+          node src/main/antora/generate-latest-version-redirects.mjs target/site
       - name: Upload reference documentation
         uses: actions/upload-artifact@v4
         with:
@@ -128,60 +132,25 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
-          REF_NAME: ${{ github.ref_name }}
-          REF_TYPE: ${{ github.ref_type }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          DISPATCH_PATH: ${{ inputs.path }}
-          DISPATCH_UPDATE_ROOT: ${{ inputs.update-root }}
         run: |
-          target_path=""
-          update_root="false"
-          remove_target="false"
-
           if [ "$EVENT_NAME" = "pull_request" ]; then
             target_path="pr-${PR_NUMBER}"
+
             if [ "$EVENT_ACTION" = "closed" ]; then
-              remove_target="true"
+              rm -rf "${SITE_DIR:?}/${target_path:?}"
+              touch "$SITE_DIR/.nojekyll"
+              exit 0
             fi
-          elif [ "$EVENT_NAME" = "push" ] && [ "$REF_TYPE" = "tag" ]; then
-            target_path="${REF_NAME#v}"
-            update_root="true"
-          elif [ "$EVENT_NAME" = "push" ] && [ "$REF_NAME" = "main" ]; then
-            target_path="snapshot"
-          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            target_path="$DISPATCH_PATH"
-            update_root="$DISPATCH_UPDATE_ROOT"
-          fi
 
-          if [ "$remove_target" = "true" ]; then
-            rm -rf "${SITE_DIR:?}/${target_path:?}"
-            exit 0
-          fi
-
-          if [ -z "$target_path" ]; then
-            find "$SITE_DIR" -mindepth 1 -maxdepth 1 \
-              ! -name ".git" \
-              ! -name ".nojekyll" \
-              ! -name "snapshot" \
-              ! -name "pr-*" \
-              ! -name "v*.*.*" \
-              ! -name "[0-9]*.[0-9]*.[0-9]*" \
-              -exec rm -rf {} +
-            cp -a "$DOCS_DIR/." "$SITE_DIR/"
-          else
             rm -rf "${SITE_DIR:?}/${target_path:?}"
             mkdir -p "$SITE_DIR/$target_path"
             cp -a "$DOCS_DIR/." "$SITE_DIR/$target_path/"
-          fi
-
-          if [ "$update_root" = "true" ]; then
+          else
             find "$SITE_DIR" -mindepth 1 -maxdepth 1 \
               ! -name ".git" \
               ! -name ".nojekyll" \
-              ! -name "snapshot" \
               ! -name "pr-*" \
-              ! -name "v*.*.*" \
-              ! -name "[0-9]*.[0-9]*.[0-9]*" \
               -exec rm -rf {} +
             cp -a "$DOCS_DIR/." "$SITE_DIR/"
           fi

--- a/README.adoc
+++ b/README.adoc
@@ -107,7 +107,7 @@ _Also see link:CONTRIBUTING.adoc[CONTRIBUTING.adoc] if you wish to submit pull r
 
 === Building reference documentation
 
-Building the documentation builds also the project without running tests.
+Build the authoring/PR preview documentation from the checked-out HEAD with Maven:
 
 [source,bash]
 ----
@@ -115,6 +115,17 @@ Building the documentation builds also the project without running tests.
 ----
 
 The generated documentation is available from `target/site/index.html`.
+
+To build the published aggregate site locally, fetch `main` and release tags first, then run the root playbook after Maven has prepared the Antora CLI dependencies:
+
+[source,bash]
+----
+ $ git fetch --tags origin main
+ $ ./mvnw -Pantora antora:antora
+ $ rm -rf target/site
+ $ npx --offline antora --to-dir target/site antora-playbook.yml
+ $ node src/main/antora/generate-latest-version-redirects.mjs target/site
+----
 
 == License
 

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,17 +1,33 @@
 # PACKAGES antora@3.2.0-alpha.6 @antora/atlas-extension@1.0.0-alpha.2 @antora/collector-extension@1.0.0-alpha.7 @springio/antora-extensions@1.13.0 @asciidoctor/tabs@1.0.0-beta.6 @springio/asciidoctor-extensions@1.0.0-alpha.11
 #
-# The purpose of this Antora playbook is to build the docs in the current branch.
+# Publish playbook: aggregate main and release tags so the Spring UI can build a version selector.
 antora:
   extensions:
-    - require: '@springio/antora-extensions'
+    - '@antora/atlas-extension'
+    - '@springio/antora-extensions/latest-version-extension'
+    - '@antora/collector-extension'
+    - require: '@springio/antora-extensions/root-component-extension'
       root_component_name: 'data-meilisearch'
+    - '@springio/antora-extensions/root-attachments-extension'
+    - '@springio/antora-extensions/static-page-extension'
 site:
   title: Spring Data Meilisearch
   url: https://junghoon-vans.github.io/spring-data-meilisearch/
 content:
   sources:
     - url: .
-      branches: HEAD
+      branches:
+        - main
+      # v0.1.x-v0.7.x tags predate the Antora start path and cannot be aggregated safely.
+      tags:
+        - v*.*.*
+        - '!v0.1.*'
+        - '!v0.2.*'
+        - '!v0.3.*'
+        - '!v0.4.*'
+        - '!v0.5.*'
+        - '!v0.6.*'
+        - '!v0.7.*'
       start_path: src/main/antora
       worktrees: true
 asciidoc:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -30,6 +30,11 @@ content:
         - '!v0.7.*'
       start_path: src/main/antora
       worktrees: true
+    - url: https://github.com/spring-projects/spring-data-commons
+      # Refname matching:
+      # https://docs.antora.org/antora/latest/playbook/content-refname-matching/
+      branches: [ main ]
+      start_path: src/main/antora
 asciidoc:
   attributes:
     hide-uri-scheme: '@'

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -42,6 +42,7 @@ asciidoc:
 urls:
   latest_version_segment: ''
 runtime:
+  fetch: true
   log:
     failure_level: warn
     format: pretty

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -53,5 +53,5 @@ runtime:
     format: pretty
 ui:
   bundle:
-    url: https://github.com/spring-io/antora-ui-spring/releases/download/v0.4.16/ui-bundle.zip
+    url: https://github.com/spring-io/antora-ui-spring/releases/download/v0.4.25/ui-bundle.zip
     snapshot: true

--- a/src/main/antora/antora-playbook.yml
+++ b/src/main/antora/antora-playbook.yml
@@ -26,6 +26,7 @@ asciidoc:
 urls:
   latest_version_segment: ''
 runtime:
+  fetch: true
   log:
     failure_level: warn
     format: pretty

--- a/src/main/antora/antora-playbook.yml
+++ b/src/main/antora/antora-playbook.yml
@@ -14,6 +14,11 @@ content:
       branches: HEAD
       start_path: src/main/antora
       worktrees: true
+    - url: https://github.com/spring-projects/spring-data-commons
+      # Refname matching:
+      # https://docs.antora.org/antora/latest/playbook/content-refname-matching/
+      branches: [ main ]
+      start_path: src/main/antora
 asciidoc:
   attributes:
     hide-uri-scheme: '@'

--- a/src/main/antora/antora-playbook.yml
+++ b/src/main/antora/antora-playbook.yml
@@ -1,6 +1,6 @@
 # PACKAGES antora@3.2.0-alpha.6 @antora/atlas-extension@1.0.0-alpha.2 @antora/collector-extension@1.0.0-alpha.7 @springio/antora-extensions@1.13.0 @asciidoctor/tabs@1.0.0-beta.6 @springio/asciidoctor-extensions@1.0.0-alpha.11
 #
-# The purpose of this Antora playbook is to build the docs in the current branch.
+# Authoring/PR preview playbook: keep this HEAD-only for local changes and pull request previews.
 antora:
   extensions:
     - require: '@springio/antora-extensions'

--- a/src/main/antora/antora-playbook.yml
+++ b/src/main/antora/antora-playbook.yml
@@ -37,5 +37,5 @@ runtime:
     format: pretty
 ui:
   bundle:
-    url: https://github.com/spring-io/antora-ui-spring/releases/download/v0.4.16/ui-bundle.zip
+    url: https://github.com/spring-io/antora-ui-spring/releases/download/v0.4.25/ui-bundle.zip
     snapshot: true

--- a/src/main/antora/generate-latest-version-redirects.mjs
+++ b/src/main/antora/generate-latest-version-redirects.mjs
@@ -1,0 +1,98 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const siteDir = process.argv[2] ?? 'target/site';
+const siteRoot = path.resolve(siteDir);
+const manifestPath = path.join(siteRoot, 'site-manifest.json');
+const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+
+for (const component of Object.values(manifest.components ?? {})) {
+  const latestVersion = component.versions?.[component.latest];
+
+  if (!latestVersion || latestVersion.prerelease) {
+    continue;
+  }
+
+  const versionSegment = getVersionSegment(component.latest);
+
+  if (!versionSegment) {
+    continue;
+  }
+
+  for (const page of latestVersion.pages ?? []) {
+    if (!page.url?.startsWith('/')) {
+      continue;
+    }
+
+    const aliasUrl = `/${versionSegment}${page.url}`;
+    const aliasPath = resolveSitePath(aliasUrl);
+    const targetPath = resolveSitePath(page.url);
+
+    if (!aliasPath || !targetPath) {
+      continue;
+    }
+
+    const relativeTarget = path.relative(path.dirname(aliasPath), targetPath).replaceAll(path.sep, '/');
+
+    await fs.mkdir(path.dirname(aliasPath), { recursive: true });
+    await fs.writeFile(aliasPath, redirectPage(relativeTarget), 'utf8');
+  }
+}
+
+function getVersionSegment(version) {
+  const match = version.match(/^(\d+\.\d+)/);
+
+  return match?.[1];
+}
+
+function resolveSitePath(urlPath) {
+  const resolvedPath = path.resolve(siteRoot, urlPath.slice(1));
+  const relativePath = path.relative(siteRoot, resolvedPath);
+
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return undefined;
+  }
+
+  return resolvedPath;
+}
+
+function redirectPage(target) {
+  const escapedTarget = escapeHtml(target);
+
+  return `<!DOCTYPE html>
+<meta charset="utf-8">
+<script>location=${scriptString(target)}</script>
+<meta http-equiv="refresh" content="0; url=${escapedTarget}">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="${escapedTarget}">${escapedTarget}</a>.</p>
+`;
+}
+
+function escapeHtml(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function scriptString(value) {
+  return JSON.stringify(value).replace(/[<>&\u2028\u2029]/g, (character) => {
+    switch (character) {
+      case '<':
+        return '\\u003C';
+      case '>':
+        return '\\u003E';
+      case '&':
+        return '\\u0026';
+      case '\u2028':
+        return '\\u2028';
+      case '\u2029':
+        return '\\u2029';
+      default:
+        return character;
+    }
+  });
+}

--- a/src/main/antora/modules/ROOT/pages/index.adoc
+++ b/src/main/antora/modules/ROOT/pages/index.adoc
@@ -14,8 +14,6 @@ xref:meilisearch-document.adoc[Document Mapping] :: Entity metadata and document
 xref:meilisearch-operations.adoc[Operations] :: Template-based index, document, and search operations
 xref:meilisearch-repositories.adoc[Repositories] :: Spring Data repository support
 xref:meilisearch-settings.adoc[Settings] :: Index settings, facets, pagination, localization, and AI-powered search settings
-{spring-data-commons-docs-url}[Spring Data Commons] :: Shared Spring Data reference documentation
-{spring-data-commons-javadoc-base}index.html[Spring Data Commons Javadoc] :: API documentation for Spring Data Commons
 xref:attachment$api/java/index.html[Javadoc] :: API documentation
 
 (C) 2023-{copyright-year} The original author(s).

--- a/src/main/antora/modules/ROOT/pages/index.adoc
+++ b/src/main/antora/modules/ROOT/pages/index.adoc
@@ -14,6 +14,8 @@ xref:meilisearch-document.adoc[Document Mapping] :: Entity metadata and document
 xref:meilisearch-operations.adoc[Operations] :: Template-based index, document, and search operations
 xref:meilisearch-repositories.adoc[Repositories] :: Spring Data repository support
 xref:meilisearch-settings.adoc[Settings] :: Index settings, facets, pagination, localization, and AI-powered search settings
+{spring-data-commons-docs-url}[Spring Data Commons] :: Shared Spring Data reference documentation
+{spring-data-commons-javadoc-base}index.html[Spring Data Commons Javadoc] :: API documentation for Spring Data Commons
 xref:attachment$api/java/index.html[Javadoc] :: API documentation
 
 (C) 2023-{copyright-year} The original author(s).

--- a/src/main/antora/resources/antora-resources/antora.yml
+++ b/src/main/antora/resources/antora-resources/antora.yml
@@ -10,8 +10,8 @@ asciidoc:
     attribute-missing: 'warn'
     commons: ${springdata.commons.docs}
     include-xml-namespaces: false
-    spring-data-commons-docs-url: https://docs.spring.io/spring-data/commons/reference
-    spring-data-commons-javadoc-base: https://docs.spring.io/spring-data/commons/docs/${springdata.commons}/api/
+    spring-data-commons-docs-url: https://docs.spring.io/spring-data/commons/reference/${springdata.commons.short}
+    spring-data-commons-javadoc-base: '{spring-data-commons-docs-url}/api/java'
     springdocsurl: https://docs.spring.io/spring-framework/reference/{springversionshort}
     springjavadocurl: https://docs.spring.io/spring-framework/docs/${spring}/javadoc-api
     spring-framework-docs: '{springdocsurl}'


### PR DESCRIPTION
## Summary
- Split reference docs builds between HEAD-only PR previews and aggregate publish builds from `main` plus release tags.
- Add latest stable redirect aliases so root remains the latest stable docs while versioned stable paths stay addressable.
- Document aggregate publish builds and expose Spring Data Commons reference/Javadoc links from the landing page.

## Verification
- `actionlint .github/workflows/docs.yml`
- `node --check src/main/antora/generate-latest-version-redirects.mjs`
- `JAVA_HOME=\"/opt/homebrew/opt/openjdk@21\" PATH=\"/opt/homebrew/opt/openjdk@21/bin:$PATH\" ./mvnw -Pantora antora:antora`
- `rm -rf target/site && JAVA_HOME=\"/opt/homebrew/opt/openjdk@21\" PATH=\"/opt/homebrew/opt/openjdk@21/bin:$PATH\" npx --offline antora --to-dir target/site antora-playbook.yml && node src/main/antora/generate-latest-version-redirects.mjs target/site`
- Verified `target/site/0.8/index.html` redirects to `../index.html` and snapshot docs remain under `/0.8-SNAPSHOT/`.

Closes #180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added pull request documentation previews
  * Enhanced documentation site with version selector support
  * Improved documentation structure for multiple releases

* **Chores**
  * Updated documentation build workflows for pull requests and releases
  * Updated UI bundle dependencies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->