### PR TITLE
Upgrade testcontainers Meilisearch dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <meilisearch-java>0.20.1</meilisearch-java>
         <okhttp>5.3.2</okhttp>
         <kotlin-stdlib>2.2.21</kotlin-stdlib>
-        <testcontainers-meilisearch>1.0.5</testcontainers-meilisearch>
+        <testcontainers-meilisearch>1.1.0</testcontainers-meilisearch>
 
         <java-module-name>spring.data.meilisearch</java-module-name>
     </properties>

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchConnection.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchConnection.java
@@ -58,9 +58,11 @@ public class MeilisearchConnection implements ExtensionContext.Store.CloseableRe
 		MeilisearchContainer meilisearchContainer = new MeilisearchContainer(dockerImageName)
 				.withMasterKey(MEILISEARCH_DEFAULT_MASTER_KEY);
 		meilisearchContainer.start();
+		String host = meilisearchContainer.getHost();
+		int port = meilisearchContainer.getMappedPort(MEILISEARCH_DEFAULT_PORT);
 
-		return MeilisearchConnectionInfo.builder().host(meilisearchContainer.getHost())
-				.port(meilisearchContainer.getMappedPort(MEILISEARCH_DEFAULT_PORT)).masterKey(MEILISEARCH_DEFAULT_MASTER_KEY)
+		return MeilisearchConnectionInfo.builder().endpoint(meilisearchContainer.getEndpoint()).host(host)
+				.port(port).masterKey(MEILISEARCH_DEFAULT_MASTER_KEY)
 				.meilisearchContainer(meilisearchContainer).build();
 	}
 

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchConnectionInfo.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchConnectionInfo.java
@@ -25,13 +25,15 @@ import io.vanslog.testcontainers.meilisearch.MeilisearchContainer;
  */
 public class MeilisearchConnectionInfo {
 
+	private final String endpoint;
 	private final String host;
 	private final int port;
 	private final String masterKey;
 	private final MeilisearchContainer meilisearchContainer;
 
-	private MeilisearchConnectionInfo(String host, int port, String masterKey,
+	private MeilisearchConnectionInfo(String endpoint, String host, int port, String masterKey,
 			MeilisearchContainer meilisearchContainer) {
+		this.endpoint = endpoint;
 		this.host = host;
 		this.port = port;
 		this.masterKey = masterKey;
@@ -44,8 +46,12 @@ public class MeilisearchConnectionInfo {
 
 	@Override
 	public String toString() {
-		return "MeilisearchConnectionInfo{" + "host='" + host + '\'' + ", port=" + port + ", masterKey='" + masterKey + '\''
-				+ ", meilisearchContainer=" + meilisearchContainer + '}';
+		return "MeilisearchConnectionInfo{" + "endpoint='" + endpoint + '\'' + ", host='" + host + '\'' + ", port="
+				+ port + ", masterKey='" + masterKey + '\'' + ", meilisearchContainer=" + meilisearchContainer + '}';
+	}
+
+	public String getEndpoint() {
+		return endpoint;
 	}
 
 	public String getHost() {
@@ -66,10 +72,16 @@ public class MeilisearchConnectionInfo {
 
 	public static class Builder {
 
+		private String endpoint;
 		private String host;
 		private int port;
 		private String masterKey;
 		private MeilisearchContainer meilisearchContainer;
+
+		public Builder endpoint(String endpoint) {
+			this.endpoint = endpoint;
+			return this;
+		}
 
 		public Builder host(String host) {
 			this.host = host;
@@ -92,7 +104,7 @@ public class MeilisearchConnectionInfo {
 		}
 
 		public MeilisearchConnectionInfo build() {
-			return new MeilisearchConnectionInfo(host, port, masterKey, meilisearchContainer);
+			return new MeilisearchConnectionInfo(endpoint, host, port, masterKey, meilisearchContainer);
 		}
 	}
 }

--- a/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchTestConfiguration.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/junit/jupiter/MeilisearchTestConfiguration.java
@@ -28,14 +28,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class MeilisearchTestConfiguration extends MeilisearchConfiguration {
 
-	private static final String HTTP = "http://";
-
 	private final MeilisearchConnectionInfo meilisearchConnectionInfo = MeilisearchConnection.meilisearchConnectionInfo();
 
 	@Override
 	public ClientConfiguration clientConfiguration() {
-		return ClientConfiguration.builder()
-				.connectedTo(HTTP + meilisearchConnectionInfo.getHost() + ":" + meilisearchConnectionInfo.getPort())
+		return ClientConfiguration.builder().connectedTo(meilisearchConnectionInfo.getEndpoint())
 				.withApiKey(meilisearchConnectionInfo.getMasterKey()).build();
 	}
 }


### PR DESCRIPTION
## Summary
- Upgrade `io.vanslog:testcontainers-meilisearch` from `1.0.5` to `1.1.0`.
- Use the new `MeilisearchContainer.getEndpoint()` API in the JUnit test harness instead of manually assembling the endpoint URL.

## Verification
- `./mvnw test` passed with 74 tests.

## Issue
- No tracker issue was provided for this dependency update.