### PR TITLE
Add instance and index operations.

### DIFF
--- a/src/main/antora/modules/ROOT/pages/meilisearch-operations.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch-operations.adoc
@@ -61,6 +61,7 @@ public class MovieController {
 
 `MeilisearchOperations` exposes concern-specific operations for APIs that are not document or search operations.
 Use `instanceOps()` for Meilisearch instance-level information and `indexOps(...)` for statistics bound to one index.
+Version and stats operations use the configured Meilisearch API key, so server-side key permissions and index restrictions still apply.
 
 .Instance and index operation usage
 ====

--- a/src/main/antora/modules/ROOT/pages/meilisearch-operations.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch-operations.adoc
@@ -6,7 +6,9 @@ Spring Data Meilisearch uses several interfaces to define the operations that ca
 
 * `DocumentOperations` defines actions to store, update and retrieve entities based on their id.
 * `SearchOperations` defines the actions to search for multiple entities using queries.
-* `MeilisearchOperations` combines the `DocumentOperations` and `SearchOperations` interfaces.
+* `MeilisearchInstanceOperations` defines instance-level actions such as health, version, and stats.
+* `MeilisearchIndexOperations` defines actions scoped to a single index.
+* `MeilisearchOperations` combines the `DocumentOperations` and `SearchOperations` interfaces and exposes accessors for instance and index operations.
 
 These interfaces correspond to the structuring of the https://www.meilisearch.com/docs/reference/api/overview[Meilisearch API].
 
@@ -52,6 +54,29 @@ public class MovieController {
 <.> Let Spring inject the provided `MeilisearchOperations` bean in the constructor.
 <.> Store a movie in the Meilisearch instance.
 <.> Retrieve the movie by id.
+====
+
+[[meilisearch.operations.instance-index]]
+== Instance and Index Operations
+
+`MeilisearchOperations` exposes concern-specific operations for APIs that are not document or search operations.
+Use `instanceOps()` for Meilisearch instance-level information and `indexOps(...)` for statistics bound to one index.
+
+.Instance and index operation usage
+====
+[source,java]
+----
+MeilisearchHealth health = meilisearchOperations.instanceOps().health();
+boolean healthy = meilisearchOperations.instanceOps().isHealthy();
+MeilisearchVersion version = meilisearchOperations.instanceOps().version();
+MeilisearchStats stats = meilisearchOperations.instanceOps().stats();
+
+MeilisearchIndexStats movieStats = meilisearchOperations.indexOps(Movie.class).stats(); <.>
+MeilisearchIndexStats namedStats = meilisearchOperations.indexOps("movies").stats(); <.>
+----
+
+<.> Resolve the index uid from the mapping metadata of the `@Document` entity class.
+<.> Bind operations directly to a non-empty index uid.
 ====
 
 [[meilisearch.operations.searchresulttypes]]

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/InstanceResponseConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/InstanceResponseConverter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.client.msc;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+import com.meilisearch.sdk.exceptions.MeilisearchException;
+import com.meilisearch.sdk.json.JsonHandler;
+import com.meilisearch.sdk.model.IndexStats;
+import com.meilisearch.sdk.model.Stats;
+
+import io.vanslog.spring.data.meilisearch.UncategorizedMeilisearchException;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchHealth;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexStats;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchStats;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchVersion;
+
+/**
+ * Converts Meilisearch instance-level SDK responses into Spring Data Meilisearch responses.
+ *
+ * @author Junghoon Ban
+ */
+class InstanceResponseConverter {
+
+	private final JsonHandler jsonHandler;
+
+	InstanceResponseConverter(JsonHandler jsonHandler) {
+
+		Assert.notNull(jsonHandler, "JsonHandler must not be null");
+		this.jsonHandler = jsonHandler;
+	}
+
+	MeilisearchHealth mapHealth(String payload) {
+
+		try {
+			HealthResponse response = jsonHandler.decode(payload, HealthResponse.class);
+			return new MeilisearchHealth(response.status);
+		} catch (MeilisearchException e) {
+			throw new UncategorizedMeilisearchException("Failed to read health response.", e);
+		}
+	}
+
+	MeilisearchVersion mapVersion(String payload) {
+
+		try {
+			VersionResponse response = jsonHandler.decode(payload, VersionResponse.class);
+			return new MeilisearchVersion(response.commitSha, response.commitDate, response.pkgVersion);
+		} catch (MeilisearchException e) {
+			throw new UncategorizedMeilisearchException("Failed to read version response.", e);
+		}
+	}
+
+	MeilisearchStats mapStats(Stats stats) {
+
+		Map<String, MeilisearchIndexStats> indexes = new LinkedHashMap<>();
+		if (stats.getIndexes() != null) {
+			stats.getIndexes().forEach((indexUid, indexStats) -> indexes.put(indexUid, mapIndexStats(indexStats)));
+		}
+
+		Date lastUpdate = stats.getLastUpdate();
+		Instant lastUpdateInstant = lastUpdate != null ? lastUpdate.toInstant() : null;
+
+		return new MeilisearchStats(stats.getDatabaseSize(), stats.getUsedDatabaseSize(), lastUpdateInstant, indexes);
+	}
+
+	MeilisearchIndexStats mapIndexStats(IndexStats stats) {
+
+		Map<String, Long> fieldDistribution = new LinkedHashMap<>();
+		if (stats.getFieldDistribution() != null) {
+			stats.getFieldDistribution()
+					.forEach((fieldName, count) -> fieldDistribution.put(fieldName, count.longValue()));
+		}
+
+		return new MeilisearchIndexStats(stats.getNumberOfDocuments(), stats.isIndexing(), fieldDistribution,
+				stats.getRawDocumentDbSize(), stats.getAvgDocumentSize(), stats.getNumberOfEmbeddedDocuments(),
+				stats.getNumberOfEmbeddings());
+	}
+
+	private static class HealthResponse {
+
+		@Nullable String status;
+	}
+
+	private static class VersionResponse {
+
+		@Nullable String commitSha;
+		@Nullable String commitDate;
+		@Nullable String pkgVersion;
+	}
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchClientExecutor.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchClientExecutor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.client.msc;
+
+import io.vanslog.spring.data.meilisearch.core.MeilisearchCallback;
+
+@FunctionalInterface
+interface MeilisearchClientExecutor {
+
+	<T> T execute(MeilisearchCallback<T> callback);
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchIndexTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchIndexTemplate.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.client.msc;
+
+import org.springframework.util.Assert;
+
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexOperations;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexStats;
+
+/**
+ * Meilisearch Java client-backed operations bound to one index.
+ *
+ * @author Junghoon Ban
+ */
+class MeilisearchIndexTemplate implements MeilisearchIndexOperations {
+
+	private final String indexUid;
+	private final MeilisearchClientExecutor executor;
+	private final InstanceResponseConverter responseConverter;
+
+	MeilisearchIndexTemplate(String indexUid, MeilisearchClientExecutor executor,
+			InstanceResponseConverter responseConverter) {
+
+		Assert.hasText(indexUid, "Index uid must not be empty");
+		Assert.notNull(executor, "MeilisearchClientExecutor must not be null");
+		Assert.notNull(responseConverter, "InstanceResponseConverter must not be null");
+		this.indexUid = indexUid;
+		this.executor = executor;
+		this.responseConverter = responseConverter;
+	}
+
+	@Override
+	public MeilisearchIndexStats stats() {
+		return responseConverter.mapIndexStats(executor.execute(client -> client.index(indexUid).getStats()));
+	}
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchInstanceTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchInstanceTemplate.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.client.msc;
+
+import org.springframework.util.Assert;
+
+import io.vanslog.spring.data.meilisearch.core.MeilisearchHealth;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchInstanceOperations;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchStats;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchVersion;
+
+/**
+ * Meilisearch Java client-backed instance operations.
+ *
+ * @author Junghoon Ban
+ */
+class MeilisearchInstanceTemplate implements MeilisearchInstanceOperations {
+
+	private final MeilisearchClientExecutor executor;
+	private final InstanceResponseConverter responseConverter;
+
+	MeilisearchInstanceTemplate(MeilisearchClientExecutor executor, InstanceResponseConverter responseConverter) {
+
+		Assert.notNull(executor, "MeilisearchClientExecutor must not be null");
+		Assert.notNull(responseConverter, "InstanceResponseConverter must not be null");
+		this.executor = executor;
+		this.responseConverter = responseConverter;
+	}
+
+	@Override
+	public MeilisearchHealth health() {
+		return responseConverter.mapHealth(executor.execute(client -> client.health()));
+	}
+
+	@Override
+	public boolean isHealthy() {
+		return Boolean.TRUE.equals(executor.execute(client -> client.isHealthy()));
+	}
+
+	@Override
+	public MeilisearchVersion version() {
+		return responseConverter.mapVersion(executor.execute(client -> client.getVersion()));
+	}
+
+	@Override
+	public MeilisearchStats stats() {
+		return responseConverter.mapStats(executor.execute(client -> client.getStats()));
+	}
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchTemplate.java
@@ -16,22 +16,15 @@
 package io.vanslog.spring.data.meilisearch.client.msc;
 
 import java.lang.reflect.Method;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meilisearch.sdk.FacetSearchRequest;
 import com.meilisearch.sdk.MultiSearchFederation;
 import com.meilisearch.sdk.MultiSearchRequest;
@@ -41,13 +34,11 @@ import com.meilisearch.sdk.exceptions.MeilisearchApiException;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.model.DocumentsQuery;
 import com.meilisearch.sdk.model.FacetSearchable;
-import com.meilisearch.sdk.model.IndexStats;
 import com.meilisearch.sdk.model.MultiSearchResult;
 import com.meilisearch.sdk.model.Results;
 import com.meilisearch.sdk.model.Searchable;
 import com.meilisearch.sdk.model.SimilarDocumentsResults;
 import com.meilisearch.sdk.model.Settings;
-import com.meilisearch.sdk.model.Stats;
 import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.model.TaskStatus;
 
@@ -58,6 +49,8 @@ import io.vanslog.spring.data.meilisearch.annotations.Document;
 import io.vanslog.spring.data.meilisearch.client.MeilisearchClient;
 import io.vanslog.spring.data.meilisearch.core.FacetHit;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchCallback;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexOperations;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchInstanceOperations;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchOperations;
 import io.vanslog.spring.data.meilisearch.core.SearchHits;
 import io.vanslog.spring.data.meilisearch.core.convert.MappingMeilisearchConverter;
@@ -82,7 +75,7 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 	private final MeilisearchConverter meilisearchConverter;
 	private final RequestConverter requestConverter;
 	private final ResponseConverter responseConverter;
-	private final ObjectMapper objectMapper;
+	private final InstanceResponseConverter instanceResponseConverter;
 	private final MeilisearchInstanceOperations instanceOperations;
 
 	public MeilisearchTemplate(MeilisearchClient meilisearchClient) {
@@ -96,8 +89,8 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 				: new MappingMeilisearchConverter(new SimpleMeilisearchMappingContext());
 		this.requestConverter = new RequestConverter();
 		this.responseConverter = new ResponseConverter();
-		this.objectMapper = new ObjectMapper();
-		this.instanceOperations = new TemplateInstanceOperations();
+		this.instanceResponseConverter = new InstanceResponseConverter(meilisearchClient.getJsonHandler());
+		this.instanceOperations = new MeilisearchInstanceTemplate(this::execute, instanceResponseConverter);
 	}
 
 	@Override
@@ -116,7 +109,7 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 	public MeilisearchIndexOperations indexOps(String indexUid) {
 
 		Assert.hasText(indexUid, "Index uid must not be empty");
-		return new TemplateIndexOperations(indexUid);
+		return new MeilisearchIndexTemplate(indexUid, this::execute, instanceResponseConverter);
 	}
 
 	@Override
@@ -368,98 +361,9 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 		return meilisearchConverter.getMappingContext().getRequiredPersistentEntity(clazz);
 	}
 
-	private MeilisearchHealth mapHealth(String payload) {
-
-		try {
-			JsonNode root = objectMapper.readTree(payload);
-			return new MeilisearchHealth(root.path("status").asText());
-		} catch (JsonProcessingException e) {
-			throw new UncategorizedMeilisearchException("Failed to read health response.", e);
-		}
-	}
-
-	private MeilisearchVersion mapVersion(String payload) {
-
-		try {
-			JsonNode root = objectMapper.readTree(payload);
-			return new MeilisearchVersion(nullableText(root, "commitSha"), nullableText(root, "commitDate"),
-					nullableText(root, "pkgVersion"));
-		} catch (JsonProcessingException e) {
-			throw new UncategorizedMeilisearchException("Failed to read version response.", e);
-		}
-	}
-
-	@Nullable
-	private String nullableText(JsonNode root, String fieldName) {
-		JsonNode field = root.get(fieldName);
-		return field != null && !field.isNull() ? field.asText() : null;
-	}
-
-	private MeilisearchStats mapStats(Stats stats) {
-
-		Map<String, MeilisearchIndexStats> indexes = new LinkedHashMap<>();
-		if (stats.getIndexes() != null) {
-			stats.getIndexes().forEach((indexUid, indexStats) -> indexes.put(indexUid, mapIndexStats(indexStats)));
-		}
-
-		Date lastUpdate = stats.getLastUpdate();
-		Instant lastUpdateInstant = lastUpdate != null ? lastUpdate.toInstant() : null;
-
-		return new MeilisearchStats(stats.getDatabaseSize(), stats.getUsedDatabaseSize(), lastUpdateInstant, indexes);
-	}
-
-	private MeilisearchIndexStats mapIndexStats(IndexStats stats) {
-
-		Map<String, Long> fieldDistribution = new LinkedHashMap<>();
-		if (stats.getFieldDistribution() != null) {
-			stats.getFieldDistribution()
-					.forEach((fieldName, count) -> fieldDistribution.put(fieldName, count.longValue()));
-		}
-
-		return new MeilisearchIndexStats(stats.getNumberOfDocuments(), stats.isIndexing(), fieldDistribution,
-				stats.getRawDocumentDbSize(), stats.getAvgDocumentSize(), stats.getNumberOfEmbeddedDocuments(),
-				stats.getNumberOfEmbeddings());
-	}
-
 	@Override
 	public MeilisearchConverter getMeilisearchConverter() {
 		return meilisearchConverter;
 	}
 
-	private class TemplateInstanceOperations implements MeilisearchInstanceOperations {
-
-		@Override
-		public MeilisearchHealth health() {
-			return mapHealth(execute(client -> client.health()));
-		}
-
-		@Override
-		public boolean isHealthy() {
-			return Boolean.TRUE.equals(execute(client -> client.isHealthy()));
-		}
-
-		@Override
-		public MeilisearchVersion version() {
-			return mapVersion(execute(client -> client.getVersion()));
-		}
-
-		@Override
-		public MeilisearchStats stats() {
-			return mapStats(execute(client -> client.getStats()));
-		}
-	}
-
-	private class TemplateIndexOperations implements MeilisearchIndexOperations {
-
-		private final String indexUid;
-
-		TemplateIndexOperations(String indexUid) {
-			this.indexUid = indexUid;
-		}
-
-		@Override
-		public MeilisearchIndexStats stats() {
-			return mapIndexStats(execute(client -> client.index(indexUid).getStats()));
-		}
-	}
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchTemplate.java
@@ -355,8 +355,9 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 	}
 
 	private MeilisearchPersistentEntity<?> getPersistentEntityFor(Class<?> clazz) {
-		Assert.hasText(clazz.getAnnotation(Document.class).indexUid(),
-				"Given class must be annotated with @Document(indexUid = \"foo\")!");
+		Document document = clazz.getAnnotation(Document.class);
+		Assert.notNull(document, "Given class must be annotated with @Document(indexUid = \"foo\")!");
+		Assert.hasText(document.indexUid(), "Given class must be annotated with @Document(indexUid = \"foo\")!");
 
 		return meilisearchConverter.getMappingContext().getRequiredPersistentEntity(clazz);
 	}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchTemplate.java
@@ -16,15 +16,22 @@
 package io.vanslog.spring.data.meilisearch.client.msc;
 
 import java.lang.reflect.Method;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meilisearch.sdk.FacetSearchRequest;
 import com.meilisearch.sdk.MultiSearchFederation;
 import com.meilisearch.sdk.MultiSearchRequest;
@@ -34,11 +41,13 @@ import com.meilisearch.sdk.exceptions.MeilisearchApiException;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 import com.meilisearch.sdk.model.DocumentsQuery;
 import com.meilisearch.sdk.model.FacetSearchable;
+import com.meilisearch.sdk.model.IndexStats;
 import com.meilisearch.sdk.model.MultiSearchResult;
 import com.meilisearch.sdk.model.Results;
 import com.meilisearch.sdk.model.Searchable;
 import com.meilisearch.sdk.model.SimilarDocumentsResults;
 import com.meilisearch.sdk.model.Settings;
+import com.meilisearch.sdk.model.Stats;
 import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.model.TaskStatus;
 
@@ -73,6 +82,8 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 	private final MeilisearchConverter meilisearchConverter;
 	private final RequestConverter requestConverter;
 	private final ResponseConverter responseConverter;
+	private final ObjectMapper objectMapper;
+	private final MeilisearchInstanceOperations instanceOperations;
 
 	public MeilisearchTemplate(MeilisearchClient meilisearchClient) {
 		this(meilisearchClient, null);
@@ -85,6 +96,27 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 				: new MappingMeilisearchConverter(new SimpleMeilisearchMappingContext());
 		this.requestConverter = new RequestConverter();
 		this.responseConverter = new ResponseConverter();
+		this.objectMapper = new ObjectMapper();
+		this.instanceOperations = new TemplateInstanceOperations();
+	}
+
+	@Override
+	public MeilisearchInstanceOperations instanceOps() {
+		return instanceOperations;
+	}
+
+	@Override
+	public MeilisearchIndexOperations indexOps(Class<?> entityClass) {
+
+		Assert.notNull(entityClass, "Entity class must not be null");
+		return indexOps(getIndexUidFor(entityClass));
+	}
+
+	@Override
+	public MeilisearchIndexOperations indexOps(String indexUid) {
+
+		Assert.hasText(indexUid, "Index uid must not be empty");
+		return new TemplateIndexOperations(indexUid);
 	}
 
 	@Override
@@ -336,8 +368,98 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 		return meilisearchConverter.getMappingContext().getRequiredPersistentEntity(clazz);
 	}
 
+	private MeilisearchHealth mapHealth(String payload) {
+
+		try {
+			JsonNode root = objectMapper.readTree(payload);
+			return new MeilisearchHealth(root.path("status").asText());
+		} catch (JsonProcessingException e) {
+			throw new UncategorizedMeilisearchException("Failed to read health response.", e);
+		}
+	}
+
+	private MeilisearchVersion mapVersion(String payload) {
+
+		try {
+			JsonNode root = objectMapper.readTree(payload);
+			return new MeilisearchVersion(nullableText(root, "commitSha"), nullableText(root, "commitDate"),
+					nullableText(root, "pkgVersion"));
+		} catch (JsonProcessingException e) {
+			throw new UncategorizedMeilisearchException("Failed to read version response.", e);
+		}
+	}
+
+	@Nullable
+	private String nullableText(JsonNode root, String fieldName) {
+		JsonNode field = root.get(fieldName);
+		return field != null && !field.isNull() ? field.asText() : null;
+	}
+
+	private MeilisearchStats mapStats(Stats stats) {
+
+		Map<String, MeilisearchIndexStats> indexes = new LinkedHashMap<>();
+		if (stats.getIndexes() != null) {
+			stats.getIndexes().forEach((indexUid, indexStats) -> indexes.put(indexUid, mapIndexStats(indexStats)));
+		}
+
+		Date lastUpdate = stats.getLastUpdate();
+		Instant lastUpdateInstant = lastUpdate != null ? lastUpdate.toInstant() : null;
+
+		return new MeilisearchStats(stats.getDatabaseSize(), stats.getUsedDatabaseSize(), lastUpdateInstant, indexes);
+	}
+
+	private MeilisearchIndexStats mapIndexStats(IndexStats stats) {
+
+		Map<String, Long> fieldDistribution = new LinkedHashMap<>();
+		if (stats.getFieldDistribution() != null) {
+			stats.getFieldDistribution()
+					.forEach((fieldName, count) -> fieldDistribution.put(fieldName, count.longValue()));
+		}
+
+		return new MeilisearchIndexStats(stats.getNumberOfDocuments(), stats.isIndexing(), fieldDistribution,
+				stats.getRawDocumentDbSize(), stats.getAvgDocumentSize(), stats.getNumberOfEmbeddedDocuments(),
+				stats.getNumberOfEmbeddings());
+	}
+
 	@Override
 	public MeilisearchConverter getMeilisearchConverter() {
 		return meilisearchConverter;
+	}
+
+	private class TemplateInstanceOperations implements MeilisearchInstanceOperations {
+
+		@Override
+		public MeilisearchHealth health() {
+			return mapHealth(execute(client -> client.health()));
+		}
+
+		@Override
+		public boolean isHealthy() {
+			return Boolean.TRUE.equals(execute(client -> client.isHealthy()));
+		}
+
+		@Override
+		public MeilisearchVersion version() {
+			return mapVersion(execute(client -> client.getVersion()));
+		}
+
+		@Override
+		public MeilisearchStats stats() {
+			return mapStats(execute(client -> client.getStats()));
+		}
+	}
+
+	private class TemplateIndexOperations implements MeilisearchIndexOperations {
+
+		private final String indexUid;
+
+		TemplateIndexOperations(String indexUid) {
+			this.indexUid = indexUid;
+		}
+
+		@Override
+		public MeilisearchIndexStats stats() {
+			return mapIndexStats(execute(client -> client.index(indexUid).getStats()));
+		}
 	}
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/package-info.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/package-info.java
@@ -15,8 +15,8 @@
  */
 
 /**
- * Meilisearch Java client-specific runtime implementation and adapters. This package contains the concrete template
- * implementation and request/response conversion code backed by {@code com.meilisearch.sdk:meilisearch-java}.
+ * Meilisearch Java client-specific runtime implementation and adapters. This package contains concrete operation
+ * templates and request/response conversion code backed by {@code com.meilisearch.sdk:meilisearch-java}.
  */
 @org.springframework.lang.NonNullApi
 @org.springframework.lang.NonNullFields

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchHealth.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchHealth.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.core;
+
+import org.springframework.util.Assert;
+
+/**
+ * Health information for a Meilisearch instance.
+ *
+ * @author Junghoon Ban
+ */
+public class MeilisearchHealth {
+
+	private final String status;
+
+	public MeilisearchHealth(String status) {
+
+		Assert.hasText(status, "Status must not be empty");
+		this.status = status;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchIndexOperations.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchIndexOperations.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.core;
+
+/**
+ * Operations for APIs scoped to a single Meilisearch index.
+ *
+ * @author Junghoon Ban
+ * @see com.meilisearch.sdk.Index
+ */
+public interface MeilisearchIndexOperations {
+
+	/**
+	 * Return statistics for the bound index.
+	 *
+	 * @return index statistics
+	 */
+	MeilisearchIndexStats stats();
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchIndexStats.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchIndexStats.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.core;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.util.Assert;
+
+/**
+ * Statistics for a Meilisearch index.
+ *
+ * @author Junghoon Ban
+ */
+public class MeilisearchIndexStats {
+
+	private final long numberOfDocuments;
+	private final boolean indexing;
+	private final Map<String, Long> fieldDistribution;
+	private final long rawDocumentDbSize;
+	private final long avgDocumentSize;
+	private final long numberOfEmbeddedDocuments;
+	private final long numberOfEmbeddings;
+
+	public MeilisearchIndexStats(long numberOfDocuments, boolean indexing, Map<String, Long> fieldDistribution,
+			long rawDocumentDbSize, long avgDocumentSize, long numberOfEmbeddedDocuments, long numberOfEmbeddings) {
+
+		Assert.notNull(fieldDistribution, "Field distribution must not be null");
+
+		this.numberOfDocuments = numberOfDocuments;
+		this.indexing = indexing;
+		this.fieldDistribution = Collections.unmodifiableMap(new LinkedHashMap<>(fieldDistribution));
+		this.rawDocumentDbSize = rawDocumentDbSize;
+		this.avgDocumentSize = avgDocumentSize;
+		this.numberOfEmbeddedDocuments = numberOfEmbeddedDocuments;
+		this.numberOfEmbeddings = numberOfEmbeddings;
+	}
+
+	public long getNumberOfDocuments() {
+		return numberOfDocuments;
+	}
+
+	public boolean isIndexing() {
+		return indexing;
+	}
+
+	public Map<String, Long> getFieldDistribution() {
+		return fieldDistribution;
+	}
+
+	public long getRawDocumentDbSize() {
+		return rawDocumentDbSize;
+	}
+
+	public long getAvgDocumentSize() {
+		return avgDocumentSize;
+	}
+
+	public long getNumberOfEmbeddedDocuments() {
+		return numberOfEmbeddedDocuments;
+	}
+
+	public long getNumberOfEmbeddings() {
+		return numberOfEmbeddings;
+	}
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchInstanceOperations.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchInstanceOperations.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.core;
+
+/**
+ * Operations for Meilisearch instance-level APIs.
+ *
+ * @author Junghoon Ban
+ * @see com.meilisearch.sdk.Client
+ */
+public interface MeilisearchInstanceOperations {
+
+	/**
+	 * Return health information for the Meilisearch instance.
+	 *
+	 * @return health information
+	 */
+	MeilisearchHealth health();
+
+	/**
+	 * Return whether the Meilisearch instance is healthy.
+	 *
+	 * @return {@literal true} if the instance is healthy
+	 */
+	boolean isHealthy();
+
+	/**
+	 * Return version information for the Meilisearch instance.
+	 *
+	 * @return version information
+	 */
+	MeilisearchVersion version();
+
+	/**
+	 * Return statistics for the Meilisearch instance.
+	 *
+	 * @return statistics
+	 */
+	MeilisearchStats stats();
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchOperations.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchOperations.java
@@ -27,6 +27,30 @@ import io.vanslog.spring.data.meilisearch.core.convert.MeilisearchConverter;
 public interface MeilisearchOperations extends DocumentOperations, SearchOperations {
 
 	/**
+	 * Return operations for instance-level APIs.
+	 *
+	 * @return instance operations
+	 */
+	MeilisearchInstanceOperations instanceOps();
+
+	/**
+	 * Return operations bound to the index resolved for the given entity class.
+	 *
+	 * @param entityClass the entity class, must be annotated with
+	 *          {@link io.vanslog.spring.data.meilisearch.annotations.Document}
+	 * @return index operations
+	 */
+	MeilisearchIndexOperations indexOps(Class<?> entityClass);
+
+	/**
+	 * Return operations bound to the given index uid.
+	 *
+	 * @param indexUid the index uid, must not be empty
+	 * @return index operations
+	 */
+	MeilisearchIndexOperations indexOps(String indexUid);
+
+	/**
 	 * Apply the default settings for the given entity class.
 	 * 
 	 * @param clazz the entity class, must be annotated with

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchStats.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchStats.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.core;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Statistics for a Meilisearch instance.
+ *
+ * @author Junghoon Ban
+ */
+public class MeilisearchStats {
+
+	private final long databaseSize;
+	private final long usedDatabaseSize;
+	@Nullable private final Instant lastUpdate;
+	private final Map<String, MeilisearchIndexStats> indexes;
+
+	public MeilisearchStats(long databaseSize, long usedDatabaseSize, @Nullable Instant lastUpdate,
+			Map<String, MeilisearchIndexStats> indexes) {
+
+		Assert.notNull(indexes, "Indexes must not be null");
+
+		this.databaseSize = databaseSize;
+		this.usedDatabaseSize = usedDatabaseSize;
+		this.lastUpdate = lastUpdate;
+		this.indexes = Collections.unmodifiableMap(new LinkedHashMap<>(indexes));
+	}
+
+	public long getDatabaseSize() {
+		return databaseSize;
+	}
+
+	public long getUsedDatabaseSize() {
+		return usedDatabaseSize;
+	}
+
+	@Nullable
+	public Instant getLastUpdate() {
+		return lastUpdate;
+	}
+
+	public Map<String, MeilisearchIndexStats> getIndexes() {
+		return indexes;
+	}
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchVersion.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchVersion.java
@@ -26,12 +26,12 @@ public class MeilisearchVersion {
 
 	@Nullable private final String commitSha;
 	@Nullable private final String commitDate;
-	@Nullable private final String pkgVersion;
+	@Nullable private final String packageVersion;
 
-	public MeilisearchVersion(@Nullable String commitSha, @Nullable String commitDate, @Nullable String pkgVersion) {
+	public MeilisearchVersion(@Nullable String commitSha, @Nullable String commitDate, @Nullable String packageVersion) {
 		this.commitSha = commitSha;
 		this.commitDate = commitDate;
-		this.pkgVersion = pkgVersion;
+		this.packageVersion = packageVersion;
 	}
 
 	@Nullable
@@ -45,7 +45,7 @@ public class MeilisearchVersion {
 	}
 
 	@Nullable
-	public String getPkgVersion() {
-		return pkgVersion;
+	public String getPackageVersion() {
+		return packageVersion;
 	}
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchVersion.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchVersion.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.core;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Version information for a Meilisearch instance.
+ *
+ * @author Junghoon Ban
+ */
+public class MeilisearchVersion {
+
+	@Nullable private final String commitSha;
+	@Nullable private final String commitDate;
+	@Nullable private final String pkgVersion;
+
+	public MeilisearchVersion(@Nullable String commitSha, @Nullable String commitDate, @Nullable String pkgVersion) {
+		this.commitSha = commitSha;
+		this.commitDate = commitDate;
+		this.pkgVersion = pkgVersion;
+	}
+
+	@Nullable
+	public String getCommitSha() {
+		return commitSha;
+	}
+
+	@Nullable
+	public String getCommitDate() {
+		return commitDate;
+	}
+
+	@Nullable
+	public String getPkgVersion() {
+		return pkgVersion;
+	}
+}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/InstanceResponseConverterUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/InstanceResponseConverterUnitTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.client.msc;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.meilisearch.sdk.json.GsonJsonHandler;
+import com.meilisearch.sdk.model.IndexStats;
+import com.meilisearch.sdk.model.Stats;
+
+import io.vanslog.spring.data.meilisearch.core.MeilisearchHealth;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexStats;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchStats;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchVersion;
+
+/**
+ * Unit tests for {@link InstanceResponseConverter}.
+ *
+ * @author Junghoon Ban
+ */
+class InstanceResponseConverterUnitTests {
+
+	private final InstanceResponseConverter converter = new InstanceResponseConverter(new GsonJsonHandler());
+
+	@Test
+	void shouldConvertHealthPayload() {
+
+		MeilisearchHealth health = converter.mapHealth("{\"status\":\"available\"}");
+
+		assertThat(health.getStatus()).isEqualTo("available");
+	}
+
+	@Test
+	void shouldConvertVersionPayload() {
+
+		MeilisearchVersion version = converter.mapVersion("""
+				{
+				  "commitSha": "b46889b5e94202a4186a0f80831d4891d2e0c67e",
+				  "commitDate": "2024-12-09T10:00:00Z",
+				  "pkgVersion": "1.12.3"
+				}
+				""");
+
+		assertThat(version.getCommitSha()).isEqualTo("b46889b5e94202a4186a0f80831d4891d2e0c67e");
+		assertThat(version.getCommitDate()).isEqualTo("2024-12-09T10:00:00Z");
+		assertThat(version.getPackageVersion()).isEqualTo("1.12.3");
+	}
+
+	@Test
+	void shouldConvertStats() {
+
+		Instant lastUpdate = Instant.parse("2024-12-09T10:00:00Z");
+		Map<String, IndexStats> indexes = new LinkedHashMap<>();
+		indexes.put("movies", indexStats());
+
+		MeilisearchStats stats = converter.mapStats(new Stats(2048, Date.from(lastUpdate), indexes, 1024));
+
+		assertThat(stats.getDatabaseSize()).isEqualTo(2048);
+		assertThat(stats.getUsedDatabaseSize()).isEqualTo(1024);
+		assertThat(stats.getLastUpdate()).isEqualTo(lastUpdate);
+		assertThat(stats.getIndexes()).containsOnlyKeys("movies");
+		assertThat(stats.getIndexes().get("movies").getNumberOfDocuments()).isEqualTo(10);
+	}
+
+	@Test
+	void shouldConvertIndexStats() {
+
+		MeilisearchIndexStats stats = converter.mapIndexStats(indexStats());
+
+		assertThat(stats.getNumberOfDocuments()).isEqualTo(10);
+		assertThat(stats.isIndexing()).isTrue();
+		assertThat(stats.getFieldDistribution()).containsEntry("title", 10L).containsEntry("genre", 8L);
+		assertThat(stats.getRawDocumentDbSize()).isEqualTo(512);
+		assertThat(stats.getAvgDocumentSize()).isEqualTo(51);
+		assertThat(stats.getNumberOfEmbeddedDocuments()).isEqualTo(7);
+		assertThat(stats.getNumberOfEmbeddings()).isEqualTo(14);
+	}
+
+	private static IndexStats indexStats() {
+
+		Map<String, Integer> fieldDistribution = new LinkedHashMap<>();
+		fieldDistribution.put("title", 10);
+		fieldDistribution.put("genre", 8);
+		return new IndexStats(10, true, fieldDistribution, 512, 51, 7, 14);
+	}
+}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfigurationUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfigurationUnitTests.java
@@ -72,6 +72,13 @@ class MeilisearchConfigurationUnitTests {
 	}
 
 	@Test
+	void shouldExposeInstanceAndIndexOperationsFromMeilisearchTemplate() {
+		assertThat(meilisearchTemplate.instanceOps()).isNotNull();
+		assertThat(meilisearchTemplate.indexOps(ApplySettingsFalseEntity.class)).isNotNull();
+		assertThat(meilisearchTemplate.indexOps("test-index-config-namespace")).isNotNull();
+	}
+
+	@Test
 	void shouldCreateMeilisearchRepository() {
 		assertThat(applySettingsFalseRepository).isNotNull();
 	}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfigurationUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfigurationUnitTests.java
@@ -79,6 +79,12 @@ class MeilisearchConfigurationUnitTests {
 	}
 
 	@Test
+	void shouldRejectNonDocumentClassForIndexOperations() {
+		assertThatIllegalArgumentException().isThrownBy(() -> meilisearchTemplate.indexOps(PlainEntity.class))
+				.withMessageContaining("@Document");
+	}
+
+	@Test
 	void shouldCreateMeilisearchRepository() {
 		assertThat(applySettingsFalseRepository).isNotNull();
 	}
@@ -87,6 +93,9 @@ class MeilisearchConfigurationUnitTests {
 
 	@Document(indexUid = "test-index-config-namespace", applySettings = false)
 	record ApplySettingsFalseEntity(@Id String id) {
+	}
+
+	record PlainEntity(String id) {
 	}
 
 	@Configuration

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateIntegrationTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateIntegrationTests.java
@@ -203,6 +203,50 @@ class MeilisearchTemplateIntegrationTests {
 	}
 
 	@Test
+	void shouldGetInstanceHealth() {
+
+		MeilisearchHealth health = meilisearchTemplate.instanceOps().health();
+
+		assertThat(health.getStatus()).isEqualTo("available");
+		assertThat(meilisearchTemplate.instanceOps().isHealthy()).isTrue();
+	}
+
+	@Test
+	void shouldGetInstanceVersion() {
+
+		MeilisearchVersion version = meilisearchTemplate.instanceOps().version();
+
+		assertThat(version.getCommitSha()).isNotBlank();
+		assertThat(version.getCommitDate()).isNotBlank();
+		assertThat(version.getPkgVersion()).isNotBlank();
+	}
+
+	@Test
+	void shouldGetStatsFromInstanceAndIndexOperations() {
+
+		meilisearchTemplate.save(List.of(movie1, movie2));
+
+		MeilisearchStats instanceStats = meilisearchTemplate.instanceOps().stats();
+		MeilisearchIndexStats indexStatsByClass = meilisearchTemplate.indexOps(Movie.class).stats();
+		MeilisearchIndexStats indexStatsByIndexUid = meilisearchTemplate.indexOps("movies").stats();
+
+		assertThat(instanceStats.getDatabaseSize()).isGreaterThanOrEqualTo(instanceStats.getUsedDatabaseSize());
+		assertThat(instanceStats.getLastUpdate()).isNotNull();
+		assertThat(instanceStats.getIndexes()).containsKey("movies");
+		assertThat(instanceStats.getIndexes().get("movies").getNumberOfDocuments()).isEqualTo(2);
+		assertThat(indexStatsByClass.getNumberOfDocuments()).isEqualTo(2);
+		assertThat(indexStatsByClass.isIndexing()).isFalse();
+		assertThat(indexStatsByClass.getFieldDistribution()).containsEntry("title", 2L);
+		assertThat(indexStatsByIndexUid.getNumberOfDocuments()).isEqualTo(2);
+	}
+
+	@Test
+	void shouldRejectBlankIndexUid() {
+
+		assertThatIllegalArgumentException().isThrownBy(() -> meilisearchTemplate.indexOps(""));
+	}
+
+	@Test
 	void shouldSearchWithBasicQuery() {
 		meilisearchTemplate.save(List.of(movie1, movie2, movie3));
 

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateIntegrationTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateIntegrationTests.java
@@ -218,7 +218,7 @@ class MeilisearchTemplateIntegrationTests {
 
 		assertThat(version.getCommitSha()).isNotBlank();
 		assertThat(version.getCommitDate()).isNotBlank();
-		assertThat(version.getPkgVersion()).isNotBlank();
+		assertThat(version.getPackageVersion()).isNotBlank();
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- Add Spring Data-style `instanceOps()` and `indexOps(...)` accessors to `MeilisearchOperations`.
- Introduce owned health, version, instance stats, and index stats result types instead of exposing raw SDK responses.
- Document the new operations and cover them with config and live Meilisearch integration tests.

## Tests

- `JAVA_HOME="/Users/junghoon/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS/Contents/Home" ./mvnw -Dtest=MeilisearchTemplateIntegrationTests,MeilisearchConfigurationUnitTests test`
- `JAVA_HOME="/Users/junghoon/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS/Contents/Home" ./mvnw test`

Closes #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Retrieve instance health status and detailed version information
  * Access runtime statistics for the entire Meilisearch instance
  * Query index-specific statistics including document counts and field distribution
  * Perform programmatic health checks and system diagnostics

* **Documentation**
  * Updated with comprehensive guidance on instance-level and index-level operations with Java examples

* **Tests**
  * Added test coverage for new instance and index operation functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/junghoon-vans/spring-data-meilisearch/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->