### PR TITLE
Refine template package boundaries.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,9 @@ spring-data-meilisearch/
 ├── TESTING.adoc                    # test command + integration-test pattern
 ├── src/main/java/io/vanslog/spring/data/meilisearch/
 │   ├── annotations/                # entity/settings annotation schema
-│   ├── client/                     # SDK client wrapper + config builder
+│   ├── client/                     # SDK client wrapper, config builder, client-backed template/adapters
 │   ├── config/                     # JavaConfig + XML namespace parser
-│   ├── core/                       # template, operations, search result model
+│   ├── core/                       # operations contracts, search result model, query/mapping support
 │   └── repository/                 # Spring Data repository bootstrap/runtime
 ├── src/main/resources/             # Spring XML namespace registrations + XSD
 ├── src/main/antora/                # Antora reference docs source and resources
@@ -30,7 +30,7 @@ Ignore generated/editor output: `target/`, `build/`, `.idea/`, `.vscode/`.
 | Task | Location | Notes |
 |------|----------|-------|
 | Client setup | `client/`, `config/MeilisearchConfiguration.java` | `ClientConfiguration.builder()`, `MeilisearchClient`, default `JsonHandler` |
-| Template operations | `core/MeilisearchTemplate.java` | CRUD/search/multi-search/facet/settings/task handling |
+| Template operations | `client/msc/MeilisearchTemplate.java` | CRUD/search/multi-search/facet/settings/task handling |
 | Query options | `core/query/` + `client/msc/RequestConverter.java` | model, builder, SDK request mapping must move together |
 | Mapping/settings | `core/mapping/` + `annotations/` | `@Document`, settings annotations, ID/index metadata |
 | Repository behavior | `repository/config/`, `repository/support/` | registrar/config extension/factory/base repository |
@@ -48,7 +48,7 @@ Ignore generated/editor output: `target/`, `build/`, `.idea/`, `.vscode/`.
 | `MeilisearchRepositoryFactoryBean` | factory bean | `repository/support/` | creates repository factory |
 | `SimpleMeilisearchRepository` | base repository | `repository/support/` | delegates CRUD/page/sort to `MeilisearchOperations` |
 | `MeilisearchOperations` | API | `core/` | public template-style operations contract |
-| `MeilisearchTemplate` | implementation | `core/` | central runtime orchestrator |
+| `MeilisearchTemplate` | implementation | `client/msc/` | Meilisearch Java client-backed runtime orchestrator |
 | `SimpleMeilisearchPersistentEntity` | metadata | `core/mapping/` | resolves index UID, applySettings, default settings |
 | `RequestConverter` / `ResponseConverter` | SDK adapters | `client/msc/` | query/result translation boundary |
 

--- a/src/main/antora/modules/ROOT/pages/meilisearch-repositories.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch-repositories.adoc
@@ -119,7 +119,7 @@ The Spring Data Meilisearch repositories can be configured using the `meilisearc
     <meilisearch:repositories base-package="com.example.repositories"/>             <.>
 
     <bean name="meilisearchTemplate"                                                <.>
-          class="io.vanslog.spring.data.meilisearch.core.MeilisearchTemplate">
+          class="io.vanslog.spring.data.meilisearch.client.msc.MeilisearchTemplate">
         <constructor-arg name="meilisearchClient" ref="meilisearchClient"/>         <.>
     </bean>
 

--- a/src/main/java/io/vanslog/spring/data/meilisearch/AGENTS.md
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/AGENTS.md
@@ -2,16 +2,16 @@
 
 ## OVERVIEW
 
-Architectural root for the Spring Data Meilisearch module: public annotations/client/config/template/repository APIs plus internal adapters.
+Architectural root for the Spring Data Meilisearch module: public annotations/client/config/operations/repository APIs plus internal adapters.
 
 ## STRUCTURE
 
 ```text
 meilisearch/
 ├── annotations/      # @Document and settings annotations consumed by core.mapping
-├── client/           # client config, SDK wrapper, SDK request/response converters
+├── client/           # client config, SDK wrapper, client-backed template/adapters
 ├── config/           # JavaConfig and XML namespace bootstrap
-├── core/             # operations/template/search hits/query/mapping/convert
+├── core/             # operations contracts/search hits/query/mapping/convert
 └── repository/       # Spring Data repository API/config/support
 ```
 
@@ -31,10 +31,10 @@ meilisearch/
 - Public integration starts with subclassing `MeilisearchConfiguration` and using `@EnableMeilisearchRepositories`.
 - `MeilisearchConfiguration` bean names matter: `meilisearchClientConfiguration`, `meilisearchClient`, `meilisearchOperations`, `meilisearchTemplate`, `jsonHandler`.
 - `@Document` is both a domain marker and repository-identifying annotation.
-- `MeilisearchTemplate` owns runtime SDK calls; lower packages prepare metadata/query/request objects for it.
+- `client/msc/MeilisearchTemplate` owns runtime SDK calls; core packages define contracts and prepare metadata/query objects for it.
 - `package-info.java` commonly marks packages with `@NonNullApi` / `@NonNullFields`; keep nullable points explicit with `@Nullable`.
 - JavaConfig bean names are public contract; XML parser/resource/docs depend on `meilisearchTemplate`, `jsonHandler`, and `api-key` semantics.
-- `client/msc` is the SDK adapter boundary: request conversion maps query/page/sort/federation options; response conversion maps SDK hits/federation metadata to `SearchHits`.
+- `client/msc` is the SDK adapter boundary: the concrete template executes SDK calls, request conversion maps query/page/sort/federation options, and response conversion maps SDK hits/federation metadata to `SearchHits`.
 - Query changes usually span `core/query`, `client/msc/RequestConverter`, docs, and integration tests; do not add builder-only state.
 - Mapping changes usually span `annotations`, `core/mapping`, mapping unit tests, and settings docs; `id` is the only implicit ID fallback and associations are unsupported.
 - Repository config uses `meilisearchTemplateRef` / `meilisearch-template-ref`; runtime repositories delegate to `MeilisearchOperations` and may apply settings on construction.

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchTemplate.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.vanslog.spring.data.meilisearch.core;
+package io.vanslog.spring.data.meilisearch.client.msc;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -47,8 +47,10 @@ import io.vanslog.spring.data.meilisearch.TaskStatusException;
 import io.vanslog.spring.data.meilisearch.UncategorizedMeilisearchException;
 import io.vanslog.spring.data.meilisearch.annotations.Document;
 import io.vanslog.spring.data.meilisearch.client.MeilisearchClient;
-import io.vanslog.spring.data.meilisearch.client.msc.RequestConverter;
-import io.vanslog.spring.data.meilisearch.client.msc.ResponseConverter;
+import io.vanslog.spring.data.meilisearch.core.FacetHit;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchCallback;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchOperations;
+import io.vanslog.spring.data.meilisearch.core.SearchHits;
 import io.vanslog.spring.data.meilisearch.core.convert.MappingMeilisearchConverter;
 import io.vanslog.spring.data.meilisearch.core.convert.MeilisearchConverter;
 import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentEntity;
@@ -59,7 +61,7 @@ import io.vanslog.spring.data.meilisearch.core.query.FacetQuery;
 import io.vanslog.spring.data.meilisearch.core.query.SimilarQuery;
 
 /**
- * Implementation of {@link io.vanslog.spring.data.meilisearch.core.MeilisearchOperations}.
+ * Meilisearch Java client-backed implementation of {@link MeilisearchOperations}.
  *
  * @author Junghoon Ban
  * @see com.meilisearch.sdk.Client

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/package-info.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/package-info.java
@@ -15,8 +15,8 @@
  */
 
 /**
- * This package contains classes that use the Meilisearch client library (com.meilisearch.sdk:meilisearch-java) to
- * access Meilisearch.
+ * Meilisearch Java client-specific runtime implementation and adapters. This package contains the concrete template
+ * implementation and request/response conversion code backed by {@code com.meilisearch.sdk:meilisearch-java}.
  */
 @org.springframework.lang.NonNullApi
 @org.springframework.lang.NonNullFields

--- a/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfiguration.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfiguration.java
@@ -17,8 +17,8 @@ package io.vanslog.spring.data.meilisearch.config;
 
 import io.vanslog.spring.data.meilisearch.client.ClientConfiguration;
 import io.vanslog.spring.data.meilisearch.client.MeilisearchClient;
+import io.vanslog.spring.data.meilisearch.client.msc.MeilisearchTemplate;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchOperations;
-import io.vanslog.spring.data.meilisearch.core.MeilisearchTemplate;
 import io.vanslog.spring.data.meilisearch.core.convert.MeilisearchConverter;
 
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/io/vanslog/spring/data/meilisearch/repository/config/EnableMeilisearchRepositories.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/repository/config/EnableMeilisearchRepositories.java
@@ -117,7 +117,7 @@ public @interface EnableMeilisearchRepositories {
 	Class<?> repositoryFactoryBeanClass() default MeilisearchRepositoryFactoryBean.class;
 
 	/**
-	 * Returns the {@link io.vanslog.spring.data.meilisearch.core.MeilisearchTemplate} bean name. This name will be used
+	 * Returns the {@link io.vanslog.spring.data.meilisearch.core.MeilisearchOperations} bean name. This name will be used
 	 * to create Meilisearch repositories discovered through this annotation. Defaults to {@code  meilisearchTemplate}.
 	 *
 	 * @return String

--- a/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
+++ b/src/main/resources/io/vanslog/spring/data/meilisearch/config/spring-meilisearch-1.0.xsd
@@ -28,7 +28,7 @@
         <xsd:annotation>
             <xsd:appinfo>
                 <tool:annotation kind="ref">
-                    <tool:assignable-to type="io.vanslog.spring.data.meilisearch.core.MeilisearchTemplate"/>
+                    <tool:assignable-to type="io.vanslog.spring.data.meilisearch.core.MeilisearchOperations"/>
                 </tool:annotation>
             </xsd:appinfo>
         </xsd:annotation>

--- a/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfigurationUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfigurationUnitTests.java
@@ -46,6 +46,7 @@ class MeilisearchConfigurationUnitTests {
 
 	@Autowired private MeilisearchClient meilisearchClient;
 	@Autowired private MeilisearchOperations meilisearchTemplate;
+	@Autowired private io.vanslog.spring.data.meilisearch.client.msc.MeilisearchTemplate clientMeilisearchTemplate;
 	@Autowired private ApplySettingsFalseRepository applySettingsFalseRepository;
 
 	@Test
@@ -63,6 +64,11 @@ class MeilisearchConfigurationUnitTests {
 	@Test
 	void shouldCreateMeilisearchTemplate() {
 		assertThat(meilisearchTemplate).isNotNull();
+	}
+
+	@Test
+	void shouldExposeClientSpecificTemplateAsMeilisearchOperations() {
+		assertThat(meilisearchTemplate).isSameAs(clientMeilisearchTemplate);
 	}
 
 	@Test

--- a/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchNamespaceHandlerUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchNamespaceHandlerUnitTests.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.*;
 import io.vanslog.spring.data.meilisearch.annotations.Document;
 import io.vanslog.spring.data.meilisearch.client.MeilisearchClient;
 import io.vanslog.spring.data.meilisearch.client.MeilisearchClientFactoryBean;
-import io.vanslog.spring.data.meilisearch.core.MeilisearchTemplate;
+import io.vanslog.spring.data.meilisearch.client.msc.MeilisearchTemplate;
 import io.vanslog.spring.data.meilisearch.repository.MeilisearchRepository;
 
 import java.lang.reflect.Field;

--- a/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchNamespaceHandlerUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchNamespaceHandlerUnitTests.java
@@ -21,6 +21,7 @@ import io.vanslog.spring.data.meilisearch.annotations.Document;
 import io.vanslog.spring.data.meilisearch.client.MeilisearchClient;
 import io.vanslog.spring.data.meilisearch.client.MeilisearchClientFactoryBean;
 import io.vanslog.spring.data.meilisearch.client.msc.MeilisearchTemplate;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchOperations;
 import io.vanslog.spring.data.meilisearch.repository.MeilisearchRepository;
 
 import java.lang.reflect.Field;
@@ -52,6 +53,7 @@ class MeilisearchNamespaceHandlerUnitTests {
 	@Test
 	void shouldCreateMeilisearchTemplate() {
 		assertThat(context.getBean(MeilisearchTemplate.class)).isInstanceOf(MeilisearchTemplate.class);
+		assertThat(context.getBean("meilisearchTemplate", MeilisearchOperations.class)).isNotNull();
 	}
 
 	@Test

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateIntegrationTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateIntegrationTests.java
@@ -43,7 +43,7 @@ import com.meilisearch.sdk.MultiSearchFederation;
 import com.meilisearch.sdk.exceptions.MeilisearchException;
 
 /**
- * Integration tests for {@link MeilisearchTemplate}.
+ * Integration tests for {@link MeilisearchOperations}.
  *
  * @author Junghoon Ban
  */

--- a/src/test/resources/io/vanslog/spring/data/meilisearch/config/namespace.xml
+++ b/src/test/resources/io/vanslog/spring/data/meilisearch/config/namespace.xml
@@ -8,7 +8,7 @@
        http://www.vanslog.io/spring/data/meilisearch/spring-meilisearch-1.0.xsd">
 
     <bean name="meilisearchTemplate"
-          class="io.vanslog.spring.data.meilisearch.core.MeilisearchTemplate">
+          class="io.vanslog.spring.data.meilisearch.client.msc.MeilisearchTemplate">
         <constructor-arg name="meilisearchClient" ref="meilisearchClient"/>
     </bean>
 


### PR DESCRIPTION
## Summary
- Move the Meilisearch Java client-backed `MeilisearchTemplate` implementation into `client.msc` and remove the old `core` concrete template class.
- Keep JavaConfig, XML namespace examples, XSD tooling metadata, and tests aligned around `MeilisearchOperations` as the Spring Data-facing contract.
- Update repository guidance and docs to reflect the refined core/client package boundary.

## Verification
- `JAVA_HOME="/Users/junghoon/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS/Contents/Home" ./mvnw -Dtest=MeilisearchConfigurationUnitTests,MeilisearchNamespaceHandlerUnitTests,MeilisearchTemplateIntegrationTests test`
- `JAVA_HOME="/Users/junghoon/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS/Contents/Home" ./mvnw test`

Closes #194
