### PR TITLE
Add release finalization automation.

### DIFF
--- a/.github/scripts/release-finalization.mjs
+++ b/.github/scripts/release-finalization.mjs
@@ -1,0 +1,184 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+
+const VERSION_PATTERNS = {
+	project: /(<artifactId>\s*spring-data-meilisearch\s*<\/artifactId>\s*<version>)([^<]+)(<\/version>)/,
+	parent: /(<parent>[\s\S]*?<artifactId>\s*spring-data-parent\s*<\/artifactId>[\s\S]*?<version>)([^<]+)(<\/version>[\s\S]*?<\/parent>)/,
+	springdataCommons: /(<springdata\.commons>)([^<]+)(<\/springdata\.commons>)/,
+};
+
+export function readPomVersions(pomXml) {
+	return {
+		projectVersion: readRequiredVersion(pomXml, VERSION_PATTERNS.project, 'project version'),
+		parentVersion: readRequiredVersion(pomXml, VERSION_PATTERNS.parent, 'spring-data-parent version'),
+		springdataCommonsVersion: readRequiredVersion(pomXml, VERSION_PATTERNS.springdataCommons,
+			'springdata.commons version'),
+	};
+}
+
+export function detectReleaseState(pomXml) {
+	const versions = readPomVersions(pomXml);
+	const checks = {
+		projectVersion: isReleaseVersion(versions.projectVersion),
+		parentVersion: isReleaseVersion(versions.parentVersion),
+		springdataCommonsVersion: isReleaseVersion(versions.springdataCommonsVersion),
+	};
+	const release = Object.values(checks).every(Boolean);
+
+	return {
+		release,
+		versions,
+		checks,
+		reason: release ? `Release POM for ${versions.projectVersion}.` : buildNonReleaseReason(versions, checks),
+	};
+}
+
+export function assertReleaseCommitSubject(version, subject) {
+	const expected = `Release ${version}.`;
+
+	if (subject !== expected) {
+		throw new Error(`Release commit subject must be "${expected}" but was "${subject}".`);
+	}
+}
+
+export function rewritePomToNextSnapshot(pomXml) {
+	const state = detectReleaseState(pomXml);
+
+	if (!state.release) {
+		throw new Error(`Cannot rewrite a non-release POM. ${state.reason}`);
+	}
+
+	const nextVersions = {
+		projectVersion: `${incrementPatch(state.versions.projectVersion)}-SNAPSHOT`,
+		parentVersion: `${state.versions.parentVersion}-SNAPSHOT`,
+		springdataCommonsVersion: `${state.versions.springdataCommonsVersion}-SNAPSHOT`,
+	};
+
+	let rewritten = replaceVersion(pomXml, VERSION_PATTERNS.project, nextVersions.projectVersion, 'project version');
+	rewritten = replaceVersion(rewritten, VERSION_PATTERNS.parent, nextVersions.parentVersion, 'spring-data-parent version');
+	rewritten = replaceVersion(rewritten, VERSION_PATTERNS.springdataCommons, nextVersions.springdataCommonsVersion,
+		'springdata.commons version');
+
+	return {
+		pomXml: rewritten,
+		nextVersions,
+	};
+}
+
+export function incrementPatch(version) {
+	if (!SEMVER_PATTERN.test(version)) {
+		throw new Error(`Version must be semver x.y.z but was "${version}".`);
+	}
+
+	const parts = version.split('.').map((part) => Number.parseInt(part, 10));
+	parts[2] += 1;
+
+	return parts.join('.');
+}
+
+function readRequiredVersion(pomXml, pattern, name) {
+	const match = pattern.exec(pomXml);
+
+	if (!match) {
+		throw new Error(`Could not find ${name} in pom.xml.`);
+	}
+
+	return match[2].trim();
+}
+
+function isReleaseVersion(version) {
+	return SEMVER_PATTERN.test(version) && !version.endsWith('-SNAPSHOT');
+}
+
+function buildNonReleaseReason(versions, checks) {
+	const invalid = Object.entries(checks)
+		.filter(([, valid]) => !valid)
+		.map(([name]) => `${name}=${versions[name]}`);
+
+	return `Not a release POM; expected semver release versions for all release-managed entries, invalid: ${invalid.join(', ')}.`;
+}
+
+function replaceVersion(pomXml, pattern, version, name) {
+	let replaced = false;
+	const rewritten = pomXml.replace(pattern, (_match, before, _current, after) => {
+		replaced = true;
+		return `${before}${version}${after}`;
+	});
+
+	if (!replaced) {
+		throw new Error(`Could not rewrite ${name} in pom.xml.`);
+	}
+
+	return rewritten;
+}
+
+function writeOutput(name, value) {
+	console.log(`${name}=${value}`);
+}
+
+function inspectPom(pomPath, subject) {
+	const pomXml = readFileSync(pomPath, 'utf8');
+	const state = detectReleaseState(pomXml);
+
+	writeOutput('release', String(state.release));
+	writeOutput('version', state.versions.projectVersion);
+	writeOutput('parent_version', state.versions.parentVersion);
+	writeOutput('springdata_commons_version', state.versions.springdataCommonsVersion);
+	writeOutput('reason', state.reason);
+
+	if (!state.release) {
+		return;
+	}
+
+	assertReleaseCommitSubject(state.versions.projectVersion, subject);
+	writeOutput('tag', `v${state.versions.projectVersion}`);
+	writeOutput('next_version', `${incrementPatch(state.versions.projectVersion)}-SNAPSHOT`);
+}
+
+function rewritePom(pomPath) {
+	const pomXml = readFileSync(pomPath, 'utf8');
+	const result = rewritePomToNextSnapshot(pomXml);
+	writeFileSync(pomPath, result.pomXml, 'utf8');
+
+	writeOutput('next_version', result.nextVersions.projectVersion);
+	writeOutput('next_parent_version', result.nextVersions.parentVersion);
+	writeOutput('next_springdata_commons_version', result.nextVersions.springdataCommonsVersion);
+}
+
+function printUsage() {
+	console.error('Usage: node .github/scripts/release-finalization.mjs inspect <pom.xml> <commit-subject>');
+	console.error('   or: node .github/scripts/release-finalization.mjs rewrite <pom.xml>');
+}
+
+function main(argv) {
+	const [command, pomPath, ...args] = argv;
+
+	if (!command || !pomPath) {
+		printUsage();
+		return 1;
+	}
+
+	if (command === 'inspect') {
+		inspectPom(pomPath, args.join(' '));
+		return 0;
+	}
+
+	if (command === 'rewrite') {
+		rewritePom(pomPath);
+		return 0;
+	}
+
+	printUsage();
+	return 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	try {
+		process.exitCode = main(process.argv.slice(2));
+	} catch (error) {
+		console.error(error.message);
+		process.exitCode = 1;
+	}
+}

--- a/.github/scripts/release-finalization.test.mjs
+++ b/.github/scripts/release-finalization.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	assertReleaseCommitSubject,
+	detectReleaseState,
+	incrementPatch,
+	readPomVersions,
+	rewritePomToNextSnapshot,
+} from './release-finalization.mjs';
+
+const releasePom = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.vanslog</groupId>
+    <artifactId>spring-data-meilisearch</artifactId>
+    <version>0.8.1</version>
+    <parent>
+        <groupId>org.springframework.data.build</groupId>
+        <artifactId>spring-data-parent</artifactId>
+        <version>3.3.13</version>
+    </parent>
+    <properties>
+        <springdata.commons>3.3.13</springdata.commons>
+    </properties>
+</project>
+`;
+
+test('reads release-managed versions from pom.xml', () => {
+	assert.deepEqual(readPomVersions(releasePom), {
+		projectVersion: '0.8.1',
+		parentVersion: '3.3.13',
+		springdataCommonsVersion: '3.3.13',
+	});
+});
+
+test('detects release pom only when all release-managed versions are semver releases', () => {
+	const state = detectReleaseState(releasePom);
+
+	assert.equal(state.release, true);
+	assert.equal(state.reason, 'Release POM for 0.8.1.');
+});
+
+test('does not treat snapshot pom as a release', () => {
+	const snapshotPom = releasePom
+		.replace('<version>0.8.1</version>', '<version>0.8.2-SNAPSHOT</version>')
+		.replace('<version>3.3.13</version>', '<version>3.3.13-SNAPSHOT</version>')
+		.replace('<springdata.commons>3.3.13</springdata.commons>',
+			'<springdata.commons>3.3.13-SNAPSHOT</springdata.commons>');
+	const state = detectReleaseState(snapshotPom);
+
+	assert.equal(state.release, false);
+	assert.match(state.reason, /projectVersion=0\.8\.2-SNAPSHOT/);
+	assert.match(state.reason, /parentVersion=3\.3\.13-SNAPSHOT/);
+	assert.match(state.reason, /springdataCommonsVersion=3\.3\.13-SNAPSHOT/);
+});
+
+test('does not treat non-semver pom as a release', () => {
+	const nonSemverPom = releasePom.replace('<version>0.8.1</version>', '<version>0.8</version>');
+
+	assert.equal(detectReleaseState(nonSemverPom).release, false);
+});
+
+test('requires exact release commit subject', () => {
+	assert.doesNotThrow(() => assertReleaseCommitSubject('0.8.1', 'Release 0.8.1.'));
+	assert.throws(() => assertReleaseCommitSubject('0.8.1', 'Release 0.8.1'),
+		/Release commit subject must be "Release 0\.8\.1\."/);
+});
+
+test('increments only the project patch for the next development iteration', () => {
+	assert.equal(incrementPatch('0.8.1'), '0.8.2');
+});
+
+test('rewrites release pom to the next snapshot pom', () => {
+	const result = rewritePomToNextSnapshot(releasePom);
+
+	assert.deepEqual(result.nextVersions, {
+		projectVersion: '0.8.2-SNAPSHOT',
+		parentVersion: '3.3.13-SNAPSHOT',
+		springdataCommonsVersion: '3.3.13-SNAPSHOT',
+	});
+	assert.match(result.pomXml, /<version>0\.8\.2-SNAPSHOT<\/version>/);
+	assert.match(result.pomXml, /<artifactId>spring-data-parent<\/artifactId>\s*<version>3\.3\.13-SNAPSHOT<\/version>/);
+	assert.match(result.pomXml, /<springdata\.commons>3\.3\.13-SNAPSHOT<\/springdata\.commons>/);
+});
+
+test('refuses to rewrite non-release pom', () => {
+	const snapshotPom = releasePom.replace('<version>0.8.1</version>', '<version>0.8.2-SNAPSHOT</version>');
+
+	assert.throws(() => rewritePomToNextSnapshot(snapshotPom), /Cannot rewrite a non-release POM/);
+});

--- a/.github/workflows/release-finalization.yml
+++ b/.github/workflows/release-finalization.yml
@@ -37,7 +37,7 @@ jobs:
     env:
       CHECKOUT_REF: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || inputs.ref || 'main' }}
       RELEASE_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
-      RELEASE_AUTOMATION_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
     steps:
       - name: Require workflow_dispatch dry run
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run != true }}
@@ -96,12 +96,12 @@ jobs:
       - name: Require release automation token
         if: ${{ github.event_name == 'workflow_run' && steps.inspect.outputs.release == 'true' }}
         run: |
-          if [ -z "$RELEASE_AUTOMATION_TOKEN" ]; then
-            echo "::error::RELEASE_AUTOMATION_TOKEN is required for live release finalization."
+          if [ -z "$RELEASE_TOKEN" ]; then
+            echo "::error::RELEASE_TOKEN is required for live release finalization."
             exit 1
           fi
 
-          git remote set-url origin "https://x-access-token:${RELEASE_AUTOMATION_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Verify release SHA is still origin/main
         if: ${{ github.event_name == 'workflow_run' && steps.inspect.outputs.release == 'true' }}
@@ -151,7 +151,7 @@ jobs:
           name: Spring Data Meilisearch ${{ steps.inspect.outputs.version }}
           commitish: ${{ env.RELEASE_SHA }}
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Prepare next development iteration
         id: next-snapshot

--- a/.github/workflows/release-finalization.yml
+++ b/.github/workflows/release-finalization.yml
@@ -1,0 +1,171 @@
+name: Release Finalization
+
+on:
+  workflow_run:
+    workflows:
+      - CD
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to inspect for a dry run
+        required: false
+        default: main
+      dry_run:
+        description: Run checks without mutating tags, releases, or branches
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  finalize:
+    name: Finalize release
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CHECKOUT_REF: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || inputs.ref || 'main' }}
+      RELEASE_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
+      RELEASE_AUTOMATION_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
+    steps:
+      - name: Require workflow_dispatch dry run
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run != true }}
+        run: |
+          echo "::error::workflow_dispatch is supported for dry runs only."
+          exit 1
+
+      - name: Checkout release candidate
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify workflow_run checkout SHA
+        if: ${{ github.event_name == 'workflow_run' }}
+        run: |
+          checked_out_sha="$(git rev-parse HEAD)"
+
+          if [ "$checked_out_sha" != "$RELEASE_SHA" ]; then
+            echo "::error::Expected checkout at $RELEASE_SHA but got $checked_out_sha."
+            exit 1
+          fi
+
+      - name: Read release commit subject
+        id: commit
+        run: |
+          subject="$(git log -1 --format=%s HEAD)"
+          sha="$(git rev-parse HEAD)"
+          {
+            echo "subject<<SUBJECT"
+            echo "$subject"
+            echo "SUBJECT"
+            echo "sha=$sha"
+          } >> "$GITHUB_OUTPUT"
+          echo "Inspecting $sha: $subject"
+
+      - name: Inspect pom.xml release state
+        id: inspect
+        env:
+          COMMIT_SUBJECT: ${{ steps.commit.outputs.subject }}
+        run: |
+          node .github/scripts/release-finalization.mjs inspect pom.xml "$COMMIT_SUBJECT" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Report no-op
+        if: ${{ steps.inspect.outputs.release != 'true' }}
+        run: |
+          echo "No release finalization needed: ${{ steps.inspect.outputs.reason }}"
+
+      - name: Report dry run
+        if: ${{ github.event_name == 'workflow_dispatch' && steps.inspect.outputs.release == 'true' }}
+        run: |
+          echo "Dry run passed for ${{ steps.inspect.outputs.tag }} at ${{ steps.commit.outputs.sha }}."
+          echo "No tag, GitHub release, or next snapshot commit was created."
+
+      - name: Require release automation token
+        if: ${{ github.event_name == 'workflow_run' && steps.inspect.outputs.release == 'true' }}
+        run: |
+          if [ -z "$RELEASE_AUTOMATION_TOKEN" ]; then
+            echo "::error::RELEASE_AUTOMATION_TOKEN is required for live release finalization."
+            exit 1
+          fi
+
+          git remote set-url origin "https://x-access-token:${RELEASE_AUTOMATION_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+      - name: Verify release SHA is still origin/main
+        if: ${{ github.event_name == 'workflow_run' && steps.inspect.outputs.release == 'true' }}
+        run: |
+          git fetch --no-tags origin main
+          main_sha="$(git rev-parse refs/remotes/origin/main)"
+
+          if [ "$main_sha" != "$RELEASE_SHA" ]; then
+            echo "::error::origin/main moved from $RELEASE_SHA to $main_sha before release finalization."
+            exit 1
+          fi
+
+      - name: Verify release tag does not exist
+        if: ${{ github.event_name == 'workflow_run' && steps.inspect.outputs.release == 'true' }}
+        run: |
+          tag="${{ steps.inspect.outputs.tag }}"
+
+          set +e
+          git ls-remote --exit-code --tags origin "refs/tags/${tag}" > /dev/null 2>&1
+          status="$?"
+          set -e
+
+          if [ "$status" = "0" ]; then
+            echo "::error::Tag ${tag} already exists."
+            exit 1
+          fi
+
+          if [ "$status" != "2" ]; then
+            echo "::error::Could not verify whether tag ${tag} exists."
+            exit "$status"
+          fi
+
+      - name: Create release tag
+        if: ${{ github.event_name == 'workflow_run' && steps.inspect.outputs.release == 'true' }}
+        run: |
+          tag="${{ steps.inspect.outputs.tag }}"
+          git tag "$tag" "$RELEASE_SHA"
+          git push origin "refs/tags/${tag}"
+
+      - name: Publish GitHub release
+        if: ${{ github.event_name == 'workflow_run' && steps.inspect.outputs.release == 'true' }}
+        uses: release-drafter/release-drafter@v6
+        with:
+          publish: true
+          tag: ${{ steps.inspect.outputs.tag }}
+          version: ${{ steps.inspect.outputs.version }}
+          name: Spring Data Meilisearch ${{ steps.inspect.outputs.version }}
+          commitish: ${{ env.RELEASE_SHA }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
+
+      - name: Prepare next development iteration
+        id: next-snapshot
+        if: ${{ github.event_name == 'workflow_run' && steps.inspect.outputs.release == 'true' }}
+        run: |
+          node .github/scripts/release-finalization.mjs rewrite pom.xml | tee -a "$GITHUB_OUTPUT"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pom.xml
+
+          if git diff --cached --quiet; then
+            echo "::error::Expected pom.xml to change for the next development iteration."
+            exit 1
+          fi
+
+          git commit -m "Prepare next development iteration."
+          git push origin HEAD:main


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/junghoon-vans/spring-data-meilisearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #196

## Summary
- Add a CD-success-gated release finalization workflow that tags the deployed release commit, publishes the Release Drafter draft, and then pushes the next snapshot commit.
- Add a dependency-free Node helper to detect release POM state, enforce `Release <version>.` commit subjects, and rewrite `pom.xml` to the next development iteration.
- Cover release detection, no-op snapshot handling, subject validation, and next snapshot rewriting with Node tests.

## Verification
- `node --test .github/scripts/release-finalization.test.mjs`
- `node .github/scripts/release-finalization.mjs inspect pom.xml "Prepare next development iteration."`
- `actionlint .github/workflows/release-finalization.yml`

## Operational Notes
- Live finalization requires `RELEASE_TOKEN` so tag and snapshot pushes can trigger downstream workflows.
- The workflow no-ops for snapshot POMs so the post-release snapshot commit does not finalize another release.
