### PR TITLE
Add runtime index settings operations.

### DIFF
--- a/src/main/antora/modules/ROOT/pages/meilisearch-operations.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch-operations.adoc
@@ -80,6 +80,14 @@ MeilisearchIndex created = catalogIndex.create();
 MeilisearchIndex updated = catalogIndex.update(new MeilisearchIndexUpdateRequest("id"));
 MeilisearchIndex loaded = catalogIndex.get();
 MeilisearchIndexList indexes = catalogIndex.list(new MeilisearchIndexQuery(0, 100));
+MeilisearchIndexSettings settings = catalogIndex.getSettings();
+MeilisearchIndexSettings updatedSettings = catalogIndex.updateSettings(
+    MeilisearchIndexSettings.builder()
+        .withSearchableAttributes(List.of("title", "description"))
+        .withFilterableAttributes(List.of("genres"))
+        .withPagination(new MeilisearchIndexSettings.PaginationSettings(1500))
+        .build());
+MeilisearchIndexSettings resetSettings = catalogIndex.resetSettings();
 boolean deleted = catalogIndex.delete();
 ----
 
@@ -92,13 +100,17 @@ boolean deleted = catalogIndex.delete();
 
 The index lifecycle API returns Spring Data Meilisearch-owned request and response types such as `MeilisearchIndex`, `MeilisearchIndexCreateRequest`, `MeilisearchIndexUpdateRequest`, `MeilisearchIndexQuery`, and `MeilisearchIndexList`.
 It does not expose Meilisearch Java SDK model types from public operation signatures.
+Runtime settings APIs follow the same rule: `MeilisearchIndexSettings` and its nested value types are Spring Data Meilisearch-owned and no `com.meilisearch.sdk.model.Settings` types are exposed.
 
 Meilisearch performs create, update, and delete operations asynchronously.
-The default template waits for the submitted task to complete using the configured request timeout and retry interval before returning from these lifecycle methods.
+The default template waits for the submitted task to complete using the configured request timeout and retry interval before returning from lifecycle methods and from settings update/reset methods.
 
 `list(...)` returns a page of indexes for the configured key; it is exposed from `indexOps(...)` to keep index management under the index operations API rather than introducing a separate admin wrapper.
 Updating an index currently covers the practical Meilisearch lifecycle update exposed for a bound index: assigning the primary key, typically before documents are added.
-Runtime settings management is separate from index lifecycle operations and remains handled by mapping/settings APIs such as `applySettings(...)`.
+Runtime settings management is exposed on the same index-scoped operations object through `getSettings()`, `updateSettings(...)`, and `resetSettings()`.
+`updateSettings(...)` sends the settings fields present in the provided `MeilisearchIndexSettings` value to Meilisearch; use empty lists or maps to clear supported list/map settings and use `resetSettings()` to restore all settings to Meilisearch defaults.
+Do not rely on `null` values to reset individual settings.
+Annotation-driven `applySettings(...)` remains available for applying settings declared on mapped entity classes and is separate from ad-hoc runtime settings updates.
 
 The API key must be allowed to perform the requested index actions.
 For restricted keys, create, retrieve/list, update, and delete operations require the corresponding Meilisearch index permissions (for example `indexes.create`, `indexes.get`, `indexes.update`, and `indexes.delete`) and must also match the key's index restrictions.

--- a/src/main/antora/modules/ROOT/pages/meilisearch-settings.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch-settings.adoc
@@ -51,6 +51,44 @@ class Product {
 ----
 ====
 
+Annotation-based settings are mapping metadata.
+They are applied when repositories initialize entities configured with `@Document(applySettings = true)` or when application code explicitly calls `MeilisearchOperations.applySettings(Entity.class)`.
+This path remains the preferred option for stable settings that belong to an entity model.
+
+Runtime settings operations are available when an application needs to inspect or adjust index settings outside entity bootstrap.
+Use the index-scoped API from `MeilisearchOperations.indexOps(...)`:
+
+====
+[source,java]
+----
+MeilisearchIndexOperations index = meilisearchOperations.indexOps(Product.class);
+
+MeilisearchIndexSettings current = index.getSettings();
+
+MeilisearchIndexSettings updated = index.updateSettings(
+    MeilisearchIndexSettings.builder()
+        .withSearchableAttributes(List.of("description", "brand", "color"))
+        .withDisplayedAttributes(List.of("description", "brand", "color", "productId"))
+        .withFilterableAttributes(List.of("brand", "color", "price"))
+        .withPagination(new MeilisearchIndexSettings.PaginationSettings(2000))
+        .build());
+
+MeilisearchIndexSettings defaults = index.resetSettings();
+----
+====
+
+The runtime API uses Spring Data Meilisearch-owned `MeilisearchIndexSettings` values.
+Public method signatures do not expose Meilisearch Java SDK settings, task, pagination, typo tolerance, faceting, embedder, or localized attribute classes.
+Runtime updates use Meilisearch's settings update task and the template waits for the task to complete before returning.
+If the task reaches a terminal status other than `SUCCEEDED`, the template raises `TaskStatusException`.
+
+`updateSettings(...)` updates the settings represented by non-null fields in `MeilisearchIndexSettings`.
+Use empty lists or maps to clear supported list/map settings and use `resetSettings()` to reset all index settings to Meilisearch defaults.
+Do not use `null` values to reset individual settings; Meilisearch SDK serializers omit null fields.
+
+The conservative runtime settings surface mirrors the annotation support documented below: searchable, displayed, sortable and filterable attributes, ranking rules, distinct attribute, synonyms, stop words, dictionary, pagination `maxTotalHits`, faceting `maxValuesPerFacet`, typo tolerance basics, tokenization settings, proximity precision, search cutoff, localized attributes, and embedders.
+Advanced Meilisearch settings not represented by these Spring Data types can still be managed outside this abstraction if needed.
+
 [[meilisearch.settings.search]]
 == Search Settings
 

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/IndexRequestConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/IndexRequestConverter.java
@@ -15,9 +15,7 @@
  */
 package io.vanslog.spring.data.meilisearch.client.msc;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,14 +26,11 @@ import com.meilisearch.sdk.model.TypoTolerance;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexQuery;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderDistributionSettings;
-import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderInputType;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderSettings;
-import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderSource;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.FacetingSettings;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.LocalizedAttributeSettings;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.PaginationSettings;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.TypoToleranceSettings;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -114,81 +109,14 @@ class IndexRequestConverter {
 		return settings;
 	}
 
-	MeilisearchIndexSettings fromSettings(Settings source) {
-
-		MeilisearchIndexSettings.Builder builder = MeilisearchIndexSettings.builder();
-
-		if (source.getSearchableAttributes() != null) {
-			builder.withSearchableAttributes(toList(source.getSearchableAttributes()));
-		}
-		if (source.getDisplayedAttributes() != null) {
-			builder.withDisplayedAttributes(toList(source.getDisplayedAttributes()));
-		}
-		if (source.getSortableAttributes() != null) {
-			builder.withSortableAttributes(toList(source.getSortableAttributes()));
-		}
-		if (source.getRankingRules() != null) {
-			builder.withRankingRules(toList(source.getRankingRules()));
-		}
-		builder.withDistinctAttribute(source.getDistinctAttribute());
-		if (source.getFilterableAttributes() != null) {
-			builder.withFilterableAttributes(toList(source.getFilterableAttributes()));
-		}
-		if (source.getSynonyms() != null) {
-			builder.withSynonyms(toSynonyms(source.getSynonyms()));
-		}
-		if (source.getStopWords() != null) {
-			builder.withStopWords(toList(source.getStopWords()));
-		}
-		if (source.getDictionary() != null) {
-			builder.withDictionary(toList(source.getDictionary()));
-		}
-		if (source.getPagination() != null) {
-			builder.withPagination(new PaginationSettings(source.getPagination().getMaxTotalHits()));
-		}
-		if (source.getFaceting() != null) {
-			builder.withFaceting(new FacetingSettings(source.getFaceting().getMaxValuesPerFacet()));
-		}
-		if (source.getTypoTolerance() != null) {
-			builder.withTypoTolerance(toTypoToleranceSettings(source.getTypoTolerance()));
-		}
-		builder.withProximityPrecision(source.getProximityPrecision());
-		builder.withSearchCutoffMs(source.getSearchCutoffMs());
-		if (source.getSeparatorTokens() != null) {
-			builder.withSeparatorTokens(toList(source.getSeparatorTokens()));
-		}
-		if (source.getNonSeparatorTokens() != null) {
-			builder.withNonSeparatorTokens(toList(source.getNonSeparatorTokens()));
-		}
-		if (source.getLocalizedAttributes() != null) {
-			builder.withLocalizedAttributes(toLocalizedAttributeSettings(source.getLocalizedAttributes()));
-		}
-		if (source.getEmbedders() != null) {
-			builder.withEmbedders(toEmbedderSettings(source.getEmbedders()));
-		}
-
-		return builder.build();
-	}
-
 	private static String[] toArray(List<String> source) {
 		return source.toArray(String[]::new);
-	}
-
-	private static List<String> toList(String[] source) {
-		return Arrays.asList(source);
 	}
 
 	private static HashMap<String, String[]> toSynonymMap(Map<String, List<String>> source) {
 
 		HashMap<String, String[]> synonyms = new HashMap<>();
 		source.forEach((word, values) -> synonyms.put(word, toArray(values)));
-		return synonyms;
-	}
-
-	private static Map<String, List<String>> toSynonyms(Map<String, String[]> source) {
-
-		Map<String, List<String>> synonyms = new LinkedHashMap<>();
-		source.forEach((word, values) -> synonyms.put(word, toList(values)));
 		return synonyms;
 	}
 
@@ -229,36 +157,12 @@ class IndexRequestConverter {
 		return typoTolerance;
 	}
 
-	private static TypoToleranceSettings toTypoToleranceSettings(TypoTolerance source) {
-
-		Integer oneTypo = getTypoSize(source, "oneTypo");
-		Integer twoTypos = getTypoSize(source, "twoTypos");
-		List<String> disableOnWords = source.getDisableOnWords() != null ? toList(source.getDisableOnWords()) : null;
-		List<String> disableOnAttributes = source.getDisableOnAttributes() != null ? toList(source.getDisableOnAttributes())
-				: null;
-
-		return new TypoToleranceSettings(source.isEnabled(), oneTypo, twoTypos, disableOnWords, disableOnAttributes);
-	}
-
-	@Nullable
-	private static Integer getTypoSize(TypoTolerance source, String key) {
-		return source.getMinWordSizeForTypos() != null ? source.getMinWordSizeForTypos().get(key) : null;
-	}
-
 	private static com.meilisearch.sdk.model.LocalizedAttribute[] toLocalizedAttributes(
 			List<LocalizedAttributeSettings> source) {
 
 		return source.stream().map(it -> new com.meilisearch.sdk.model.LocalizedAttribute(
 				toArray(it.getAttributePatterns()), toArray(it.getLocales())))
 				.toArray(com.meilisearch.sdk.model.LocalizedAttribute[]::new);
-	}
-
-	private static List<LocalizedAttributeSettings> toLocalizedAttributeSettings(
-			com.meilisearch.sdk.model.LocalizedAttribute[] source) {
-
-		return Arrays.stream(source)
-				.map(it -> new LocalizedAttributeSettings(toList(it.getAttributePatterns()), toList(it.getLocales())))
-				.toList();
 	}
 
 	private static HashMap<String, com.meilisearch.sdk.model.Embedder> toEmbedders(
@@ -334,48 +238,4 @@ class IndexRequestConverter {
 		return com.meilisearch.sdk.model.EmbedderDistribution.custom(source.getMean(), source.getSigma());
 	}
 
-	private static Map<String, EmbedderSettings> toEmbedderSettings(
-			Map<String, com.meilisearch.sdk.model.Embedder> source) {
-
-		Map<String, EmbedderSettings> embedders = new LinkedHashMap<>();
-		source.forEach((name, embedder) -> embedders.put(name, toEmbedderSettings(embedder)));
-		return embedders;
-	}
-
-	private static EmbedderSettings toEmbedderSettings(com.meilisearch.sdk.model.Embedder source) {
-
-		EmbedderSettings.EmbedderBuilder builder = EmbedderSettings.builder();
-		if (source.getSource() != null) {
-			builder.withSource(EmbedderSource.valueOf(source.getSource().name()));
-		}
-		builder.withApiKey(source.getApiKey());
-		builder.withModel(source.getModel());
-		builder.withDocumentTemplate(source.getDocumentTemplate());
-		builder.withDimensions(source.getDimensions());
-		if (source.getDistribution() != null) {
-			builder.withDistribution(new EmbedderDistributionSettings(source.getDistribution().getMean(),
-					source.getDistribution().getSigma()));
-		}
-		if (source.getRequest() != null) {
-			builder.withRequest(source.getRequest());
-		}
-		if (source.getResponse() != null) {
-			builder.withResponse(source.getResponse());
-		}
-		builder.withDocumentTemplateMaxBytes(source.getDocumentTemplateMaxBytes());
-		builder.withRevision(source.getRevision());
-		if (source.getHeaders() != null) {
-			builder.withHeaders(source.getHeaders());
-		}
-		builder.withBinaryQuantized(source.getBinaryQuantized());
-		builder.withUrl(source.getUrl());
-		if (source.getInputField() != null) {
-			builder.withInputField(toList(source.getInputField()));
-		}
-		if (source.getInputType() != null) {
-			builder.withInputType(EmbedderInputType.valueOf(source.getInputType().name()));
-		}
-		builder.withQuery(source.getQuery());
-		return builder.build();
-	}
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/IndexRequestConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/IndexRequestConverter.java
@@ -15,9 +15,28 @@
  */
 package io.vanslog.spring.data.meilisearch.client.msc;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.meilisearch.sdk.model.IndexesQuery;
+import com.meilisearch.sdk.model.Settings;
+import com.meilisearch.sdk.model.TypoTolerance;
 
 import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexQuery;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderDistributionSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderInputType;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderSource;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.FacetingSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.LocalizedAttributeSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.PaginationSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.TypoToleranceSettings;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * Converts Spring Data Meilisearch index lifecycle requests into SDK requests.
@@ -31,5 +50,332 @@ class IndexRequestConverter {
 		return new IndexesQuery() //
 				.setOffset(query.getOffset()) //
 				.setLimit(query.getLimit());
+	}
+
+	Settings toSettings(MeilisearchIndexSettings source) {
+
+		Settings settings = new Settings();
+
+		if (source.getSearchableAttributes() != null) {
+			settings.setSearchableAttributes(toArray(source.getSearchableAttributes()));
+		}
+		if (source.getDisplayedAttributes() != null) {
+			settings.setDisplayedAttributes(toArray(source.getDisplayedAttributes()));
+		}
+		if (source.getSortableAttributes() != null) {
+			settings.setSortableAttributes(toArray(source.getSortableAttributes()));
+		}
+		if (source.getRankingRules() != null) {
+			settings.setRankingRules(toArray(source.getRankingRules()));
+		}
+		if (source.getDistinctAttribute() != null) {
+			settings.setDistinctAttribute(source.getDistinctAttribute());
+		}
+		if (source.getFilterableAttributes() != null) {
+			settings.setFilterableAttributes(toArray(source.getFilterableAttributes()));
+		}
+		if (source.getSynonyms() != null) {
+			settings.setSynonyms(toSynonymMap(source.getSynonyms()));
+		}
+		if (source.getStopWords() != null) {
+			settings.setStopWords(toArray(source.getStopWords()));
+		}
+		if (source.getDictionary() != null) {
+			settings.setDictionary(toArray(source.getDictionary()));
+		}
+		if (source.getPagination() != null) {
+			settings.setPagination(toPagination(source.getPagination()));
+		}
+		if (source.getFaceting() != null) {
+			settings.setFaceting(toFaceting(source.getFaceting()));
+		}
+		if (source.getTypoTolerance() != null) {
+			settings.setTypoTolerance(toTypoTolerance(source.getTypoTolerance()));
+		}
+		if (source.getProximityPrecision() != null) {
+			settings.setProximityPrecision(source.getProximityPrecision());
+		}
+		if (source.getSearchCutoffMs() != null) {
+			settings.setSearchCutoffMs(source.getSearchCutoffMs());
+		}
+		if (source.getSeparatorTokens() != null) {
+			settings.setSeparatorTokens(toArray(source.getSeparatorTokens()));
+		}
+		if (source.getNonSeparatorTokens() != null) {
+			settings.setNonSeparatorTokens(toArray(source.getNonSeparatorTokens()));
+		}
+		if (source.getLocalizedAttributes() != null) {
+			settings.setLocalizedAttributes(toLocalizedAttributes(source.getLocalizedAttributes()));
+		}
+		if (source.getEmbedders() != null) {
+			settings.setEmbedders(toEmbedders(source.getEmbedders()));
+		}
+
+		return settings;
+	}
+
+	MeilisearchIndexSettings fromSettings(Settings source) {
+
+		MeilisearchIndexSettings.Builder builder = MeilisearchIndexSettings.builder();
+
+		if (source.getSearchableAttributes() != null) {
+			builder.withSearchableAttributes(toList(source.getSearchableAttributes()));
+		}
+		if (source.getDisplayedAttributes() != null) {
+			builder.withDisplayedAttributes(toList(source.getDisplayedAttributes()));
+		}
+		if (source.getSortableAttributes() != null) {
+			builder.withSortableAttributes(toList(source.getSortableAttributes()));
+		}
+		if (source.getRankingRules() != null) {
+			builder.withRankingRules(toList(source.getRankingRules()));
+		}
+		builder.withDistinctAttribute(source.getDistinctAttribute());
+		if (source.getFilterableAttributes() != null) {
+			builder.withFilterableAttributes(toList(source.getFilterableAttributes()));
+		}
+		if (source.getSynonyms() != null) {
+			builder.withSynonyms(toSynonyms(source.getSynonyms()));
+		}
+		if (source.getStopWords() != null) {
+			builder.withStopWords(toList(source.getStopWords()));
+		}
+		if (source.getDictionary() != null) {
+			builder.withDictionary(toList(source.getDictionary()));
+		}
+		if (source.getPagination() != null) {
+			builder.withPagination(new PaginationSettings(source.getPagination().getMaxTotalHits()));
+		}
+		if (source.getFaceting() != null) {
+			builder.withFaceting(new FacetingSettings(source.getFaceting().getMaxValuesPerFacet()));
+		}
+		if (source.getTypoTolerance() != null) {
+			builder.withTypoTolerance(toTypoToleranceSettings(source.getTypoTolerance()));
+		}
+		builder.withProximityPrecision(source.getProximityPrecision());
+		builder.withSearchCutoffMs(source.getSearchCutoffMs());
+		if (source.getSeparatorTokens() != null) {
+			builder.withSeparatorTokens(toList(source.getSeparatorTokens()));
+		}
+		if (source.getNonSeparatorTokens() != null) {
+			builder.withNonSeparatorTokens(toList(source.getNonSeparatorTokens()));
+		}
+		if (source.getLocalizedAttributes() != null) {
+			builder.withLocalizedAttributes(toLocalizedAttributeSettings(source.getLocalizedAttributes()));
+		}
+		if (source.getEmbedders() != null) {
+			builder.withEmbedders(toEmbedderSettings(source.getEmbedders()));
+		}
+
+		return builder.build();
+	}
+
+	private static String[] toArray(List<String> source) {
+		return source.toArray(String[]::new);
+	}
+
+	private static List<String> toList(String[] source) {
+		return Arrays.asList(source);
+	}
+
+	private static HashMap<String, String[]> toSynonymMap(Map<String, List<String>> source) {
+
+		HashMap<String, String[]> synonyms = new HashMap<>();
+		source.forEach((word, values) -> synonyms.put(word, toArray(values)));
+		return synonyms;
+	}
+
+	private static Map<String, List<String>> toSynonyms(Map<String, String[]> source) {
+
+		Map<String, List<String>> synonyms = new LinkedHashMap<>();
+		source.forEach((word, values) -> synonyms.put(word, toList(values)));
+		return synonyms;
+	}
+
+	private static com.meilisearch.sdk.model.Pagination toPagination(PaginationSettings source) {
+
+		com.meilisearch.sdk.model.Pagination pagination = new com.meilisearch.sdk.model.Pagination();
+		pagination.setMaxTotalHits(source.getMaxTotalHits());
+		return pagination;
+	}
+
+	private static com.meilisearch.sdk.model.Faceting toFaceting(FacetingSettings source) {
+
+		com.meilisearch.sdk.model.Faceting faceting = new com.meilisearch.sdk.model.Faceting();
+		faceting.setMaxValuesPerFacet(source.getMaxValuesPerFacet());
+		return faceting;
+	}
+
+	private static TypoTolerance toTypoTolerance(TypoToleranceSettings source) {
+
+		TypoTolerance typoTolerance = new TypoTolerance();
+		typoTolerance.setEnabled(source.isEnabled());
+		HashMap<String, Integer> minWordSizeForTypos = new HashMap<>();
+		if (source.getOneTypo() != null) {
+			minWordSizeForTypos.put("oneTypo", source.getOneTypo());
+		}
+		if (source.getTwoTypos() != null) {
+			minWordSizeForTypos.put("twoTypos", source.getTwoTypos());
+		}
+		if (!minWordSizeForTypos.isEmpty()) {
+			typoTolerance.setMinWordSizeForTypos(minWordSizeForTypos);
+		}
+		if (source.getDisableOnWords() != null) {
+			typoTolerance.setDisableOnWords(toArray(source.getDisableOnWords()));
+		}
+		if (source.getDisableOnAttributes() != null) {
+			typoTolerance.setDisableOnAttributes(toArray(source.getDisableOnAttributes()));
+		}
+		return typoTolerance;
+	}
+
+	private static TypoToleranceSettings toTypoToleranceSettings(TypoTolerance source) {
+
+		Integer oneTypo = getTypoSize(source, "oneTypo");
+		Integer twoTypos = getTypoSize(source, "twoTypos");
+		List<String> disableOnWords = source.getDisableOnWords() != null ? toList(source.getDisableOnWords()) : null;
+		List<String> disableOnAttributes = source.getDisableOnAttributes() != null ? toList(source.getDisableOnAttributes())
+				: null;
+
+		return new TypoToleranceSettings(source.isEnabled(), oneTypo, twoTypos, disableOnWords, disableOnAttributes);
+	}
+
+	@Nullable
+	private static Integer getTypoSize(TypoTolerance source, String key) {
+		return source.getMinWordSizeForTypos() != null ? source.getMinWordSizeForTypos().get(key) : null;
+	}
+
+	private static com.meilisearch.sdk.model.LocalizedAttribute[] toLocalizedAttributes(
+			List<LocalizedAttributeSettings> source) {
+
+		return source.stream().map(it -> new com.meilisearch.sdk.model.LocalizedAttribute(
+				toArray(it.getAttributePatterns()), toArray(it.getLocales())))
+				.toArray(com.meilisearch.sdk.model.LocalizedAttribute[]::new);
+	}
+
+	private static List<LocalizedAttributeSettings> toLocalizedAttributeSettings(
+			com.meilisearch.sdk.model.LocalizedAttribute[] source) {
+
+		return Arrays.stream(source)
+				.map(it -> new LocalizedAttributeSettings(toList(it.getAttributePatterns()), toList(it.getLocales())))
+				.toList();
+	}
+
+	private static HashMap<String, com.meilisearch.sdk.model.Embedder> toEmbedders(
+			Map<String, EmbedderSettings> source) {
+
+		HashMap<String, com.meilisearch.sdk.model.Embedder> embedders = new HashMap<>();
+		source.forEach((name, embedder) -> {
+			Assert.hasText(name, "Embedder name must not be blank");
+			embedders.put(name, toEmbedder(embedder));
+		});
+		return embedders;
+	}
+
+	private static com.meilisearch.sdk.model.Embedder toEmbedder(EmbedderSettings source) {
+
+		com.meilisearch.sdk.model.Embedder embedder = new com.meilisearch.sdk.model.Embedder();
+		if (source.getSource() != null) {
+			embedder.setSource(com.meilisearch.sdk.model.EmbedderSource.valueOf(source.getSource().name()));
+		}
+		if (source.getApiKey() != null) {
+			embedder.setApiKey(source.getApiKey());
+		}
+		if (source.getModel() != null) {
+			embedder.setModel(source.getModel());
+		}
+		if (source.getDocumentTemplate() != null) {
+			embedder.setDocumentTemplate(source.getDocumentTemplate());
+		}
+		if (source.getDimensions() != null) {
+			embedder.setDimensions(source.getDimensions());
+		}
+		if (source.getDistribution() != null) {
+			embedder.setDistribution(toEmbedderDistribution(source.getDistribution()));
+		}
+		if (source.getRequest() != null) {
+			embedder.setRequest(source.getRequest());
+		}
+		if (source.getResponse() != null) {
+			embedder.setResponse(source.getResponse());
+		}
+		if (source.getDocumentTemplateMaxBytes() != null) {
+			embedder.setDocumentTemplateMaxBytes(source.getDocumentTemplateMaxBytes());
+		}
+		if (source.getRevision() != null) {
+			embedder.setRevision(source.getRevision());
+		}
+		if (source.getHeaders() != null) {
+			embedder.setHeaders(source.getHeaders());
+		}
+		if (source.getBinaryQuantized() != null) {
+			embedder.setBinaryQuantized(source.getBinaryQuantized());
+		}
+		if (source.getUrl() != null) {
+			embedder.setUrl(source.getUrl());
+		}
+		if (source.getInputField() != null) {
+			embedder.setInputField(toArray(source.getInputField()));
+		}
+		if (source.getInputType() != null) {
+			embedder.setInputType(com.meilisearch.sdk.model.EmbedderInputType.valueOf(source.getInputType().name()));
+		}
+		if (source.getQuery() != null) {
+			embedder.setQuery(source.getQuery());
+		}
+		return embedder;
+	}
+
+	private static com.meilisearch.sdk.model.EmbedderDistribution toEmbedderDistribution(
+			EmbedderDistributionSettings source) {
+
+		Assert.isTrue(source.getMean() != null && source.getSigma() != null,
+				"Embedder distribution mean and sigma must be configured together");
+		return com.meilisearch.sdk.model.EmbedderDistribution.custom(source.getMean(), source.getSigma());
+	}
+
+	private static Map<String, EmbedderSettings> toEmbedderSettings(
+			Map<String, com.meilisearch.sdk.model.Embedder> source) {
+
+		Map<String, EmbedderSettings> embedders = new LinkedHashMap<>();
+		source.forEach((name, embedder) -> embedders.put(name, toEmbedderSettings(embedder)));
+		return embedders;
+	}
+
+	private static EmbedderSettings toEmbedderSettings(com.meilisearch.sdk.model.Embedder source) {
+
+		EmbedderSettings.EmbedderBuilder builder = EmbedderSettings.builder();
+		if (source.getSource() != null) {
+			builder.withSource(EmbedderSource.valueOf(source.getSource().name()));
+		}
+		builder.withApiKey(source.getApiKey());
+		builder.withModel(source.getModel());
+		builder.withDocumentTemplate(source.getDocumentTemplate());
+		builder.withDimensions(source.getDimensions());
+		if (source.getDistribution() != null) {
+			builder.withDistribution(new EmbedderDistributionSettings(source.getDistribution().getMean(),
+					source.getDistribution().getSigma()));
+		}
+		if (source.getRequest() != null) {
+			builder.withRequest(source.getRequest());
+		}
+		if (source.getResponse() != null) {
+			builder.withResponse(source.getResponse());
+		}
+		builder.withDocumentTemplateMaxBytes(source.getDocumentTemplateMaxBytes());
+		builder.withRevision(source.getRevision());
+		if (source.getHeaders() != null) {
+			builder.withHeaders(source.getHeaders());
+		}
+		builder.withBinaryQuantized(source.getBinaryQuantized());
+		builder.withUrl(source.getUrl());
+		if (source.getInputField() != null) {
+			builder.withInputField(toList(source.getInputField()));
+		}
+		if (source.getInputType() != null) {
+			builder.withInputType(EmbedderInputType.valueOf(source.getInputType().name()));
+		}
+		builder.withQuery(source.getQuery());
+		return builder.build();
 	}
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/IndexSettingsResponseConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/IndexSettingsResponseConverter.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.client.msc;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.meilisearch.sdk.model.Settings;
+import com.meilisearch.sdk.model.TypoTolerance;
+
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderDistributionSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderInputType;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderSource;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.FacetingSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.LocalizedAttributeSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.PaginationSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.TypoToleranceSettings;
+import org.springframework.lang.Nullable;
+
+/**
+ * Converts SDK index settings responses into Spring Data Meilisearch settings values.
+ *
+ * @author Junghoon Ban
+ */
+class IndexSettingsResponseConverter {
+
+	MeilisearchIndexSettings fromSettings(Settings source) {
+
+		MeilisearchIndexSettings.Builder builder = MeilisearchIndexSettings.builder();
+
+		if (source.getSearchableAttributes() != null) {
+			builder.withSearchableAttributes(toList(source.getSearchableAttributes()));
+		}
+		if (source.getDisplayedAttributes() != null) {
+			builder.withDisplayedAttributes(toList(source.getDisplayedAttributes()));
+		}
+		if (source.getSortableAttributes() != null) {
+			builder.withSortableAttributes(toList(source.getSortableAttributes()));
+		}
+		if (source.getRankingRules() != null) {
+			builder.withRankingRules(toList(source.getRankingRules()));
+		}
+		builder.withDistinctAttribute(source.getDistinctAttribute());
+		if (source.getFilterableAttributes() != null) {
+			builder.withFilterableAttributes(toList(source.getFilterableAttributes()));
+		}
+		if (source.getSynonyms() != null) {
+			builder.withSynonyms(toSynonyms(source.getSynonyms()));
+		}
+		if (source.getStopWords() != null) {
+			builder.withStopWords(toList(source.getStopWords()));
+		}
+		if (source.getDictionary() != null) {
+			builder.withDictionary(toList(source.getDictionary()));
+		}
+		if (source.getPagination() != null) {
+			builder.withPagination(new PaginationSettings(source.getPagination().getMaxTotalHits()));
+		}
+		if (source.getFaceting() != null) {
+			builder.withFaceting(new FacetingSettings(source.getFaceting().getMaxValuesPerFacet()));
+		}
+		if (source.getTypoTolerance() != null) {
+			builder.withTypoTolerance(toTypoToleranceSettings(source.getTypoTolerance()));
+		}
+		builder.withProximityPrecision(source.getProximityPrecision());
+		builder.withSearchCutoffMs(source.getSearchCutoffMs());
+		if (source.getSeparatorTokens() != null) {
+			builder.withSeparatorTokens(toList(source.getSeparatorTokens()));
+		}
+		if (source.getNonSeparatorTokens() != null) {
+			builder.withNonSeparatorTokens(toList(source.getNonSeparatorTokens()));
+		}
+		if (source.getLocalizedAttributes() != null) {
+			builder.withLocalizedAttributes(toLocalizedAttributeSettings(source.getLocalizedAttributes()));
+		}
+		if (source.getEmbedders() != null) {
+			builder.withEmbedders(toEmbedderSettings(source.getEmbedders()));
+		}
+
+		return builder.build();
+	}
+
+	private static List<String> toList(String[] source) {
+		return Arrays.asList(source);
+	}
+
+	private static Map<String, List<String>> toSynonyms(Map<String, String[]> source) {
+
+		Map<String, List<String>> synonyms = new LinkedHashMap<>();
+		source.forEach((word, values) -> synonyms.put(word, toList(values)));
+		return synonyms;
+	}
+
+	private static TypoToleranceSettings toTypoToleranceSettings(TypoTolerance source) {
+
+		Integer oneTypo = getTypoSize(source, "oneTypo");
+		Integer twoTypos = getTypoSize(source, "twoTypos");
+		List<String> disableOnWords = source.getDisableOnWords() != null ? toList(source.getDisableOnWords()) : null;
+		List<String> disableOnAttributes = source.getDisableOnAttributes() != null ? toList(source.getDisableOnAttributes())
+				: null;
+
+		return new TypoToleranceSettings(source.isEnabled(), oneTypo, twoTypos, disableOnWords, disableOnAttributes);
+	}
+
+	@Nullable
+	private static Integer getTypoSize(TypoTolerance source, String key) {
+		return source.getMinWordSizeForTypos() != null ? source.getMinWordSizeForTypos().get(key) : null;
+	}
+
+	private static List<LocalizedAttributeSettings> toLocalizedAttributeSettings(
+			com.meilisearch.sdk.model.LocalizedAttribute[] source) {
+
+		return Arrays.stream(source)
+				.map(it -> new LocalizedAttributeSettings(toList(it.getAttributePatterns()), toList(it.getLocales())))
+				.toList();
+	}
+
+	private static Map<String, EmbedderSettings> toEmbedderSettings(
+			Map<String, com.meilisearch.sdk.model.Embedder> source) {
+
+		Map<String, EmbedderSettings> embedders = new LinkedHashMap<>();
+		source.forEach((name, embedder) -> embedders.put(name, toEmbedderSettings(embedder)));
+		return embedders;
+	}
+
+	private static EmbedderSettings toEmbedderSettings(com.meilisearch.sdk.model.Embedder source) {
+
+		EmbedderSettings.EmbedderBuilder builder = EmbedderSettings.builder();
+		if (source.getSource() != null) {
+			builder.withSource(EmbedderSource.valueOf(source.getSource().name()));
+		}
+		builder.withApiKey(source.getApiKey());
+		builder.withModel(source.getModel());
+		builder.withDocumentTemplate(source.getDocumentTemplate());
+		builder.withDimensions(source.getDimensions());
+		if (source.getDistribution() != null) {
+			builder.withDistribution(new EmbedderDistributionSettings(source.getDistribution().getMean(),
+					source.getDistribution().getSigma()));
+		}
+		if (source.getRequest() != null) {
+			builder.withRequest(source.getRequest());
+		}
+		if (source.getResponse() != null) {
+			builder.withResponse(source.getResponse());
+		}
+		builder.withDocumentTemplateMaxBytes(source.getDocumentTemplateMaxBytes());
+		builder.withRevision(source.getRevision());
+		if (source.getHeaders() != null) {
+			builder.withHeaders(source.getHeaders());
+		}
+		builder.withBinaryQuantized(source.getBinaryQuantized());
+		builder.withUrl(source.getUrl());
+		if (source.getInputField() != null) {
+			builder.withInputField(toList(source.getInputField()));
+		}
+		if (source.getInputType() != null) {
+			builder.withInputType(EmbedderInputType.valueOf(source.getInputType().name()));
+		}
+		builder.withQuery(source.getQuery());
+		return builder.build();
+	}
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchIndexTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchIndexTemplate.java
@@ -42,6 +42,7 @@ class MeilisearchIndexTemplate implements MeilisearchIndexOperations {
 	private final String indexUid;
 	private final MeilisearchClientExecutor executor;
 	private final IndexRequestConverter requestConverter;
+	private final IndexSettingsResponseConverter settingsResponseConverter;
 	private final InstanceResponseConverter responseConverter;
 	private final int requestTimeout;
 	private final int requestInterval;
@@ -55,6 +56,7 @@ class MeilisearchIndexTemplate implements MeilisearchIndexOperations {
 		this.indexUid = indexUid;
 		this.executor = executor;
 		this.requestConverter = new IndexRequestConverter();
+		this.settingsResponseConverter = new IndexSettingsResponseConverter();
 		this.responseConverter = responseConverter;
 		this.requestTimeout = requestTimeout;
 		this.requestInterval = requestInterval;
@@ -126,7 +128,7 @@ class MeilisearchIndexTemplate implements MeilisearchIndexOperations {
 
 	@Override
 	public MeilisearchIndexSettings getSettings() {
-		return requestConverter.fromSettings(executor.execute(client -> client.index(indexUid).getSettings()));
+		return settingsResponseConverter.fromSettings(executor.execute(client -> client.index(indexUid).getSettings()));
 	}
 
 	@Override

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchIndexTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchIndexTemplate.java
@@ -18,6 +18,7 @@ package io.vanslog.spring.data.meilisearch.client.msc;
 import org.springframework.util.Assert;
 
 import com.meilisearch.sdk.model.IndexesQuery;
+import com.meilisearch.sdk.model.Settings;
 import com.meilisearch.sdk.model.TaskInfo;
 import com.meilisearch.sdk.model.TaskStatus;
 
@@ -27,6 +28,7 @@ import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexCreateRequest;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexList;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexOperations;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexQuery;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexStats;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexUpdateRequest;
 
@@ -120,6 +122,38 @@ class MeilisearchIndexTemplate implements MeilisearchIndexOperations {
 	@Override
 	public MeilisearchIndexStats stats() {
 		return responseConverter.mapIndexStats(executor.execute(client -> client.index(indexUid).getStats()));
+	}
+
+	@Override
+	public MeilisearchIndexSettings getSettings() {
+		return requestConverter.fromSettings(executor.execute(client -> client.index(indexUid).getSettings()));
+	}
+
+	@Override
+	public MeilisearchIndexSettings updateSettings(MeilisearchIndexSettings settings) {
+
+		Assert.notNull(settings, "MeilisearchIndexSettings must not be null");
+
+		Settings sdkSettings = requestConverter.toSettings(settings);
+		TaskInfo taskInfo = executor.execute(client -> client.index(indexUid).updateSettings(sdkSettings));
+		TaskStatus taskStatus = waitForTask(taskInfo);
+		if (taskStatus != TaskStatus.SUCCEEDED) {
+			throw new TaskStatusException(taskStatus, "Failed to update index settings.");
+		}
+
+		return getSettings();
+	}
+
+	@Override
+	public MeilisearchIndexSettings resetSettings() {
+
+		TaskInfo taskInfo = executor.execute(client -> client.index(indexUid).resetSettings());
+		TaskStatus taskStatus = waitForTask(taskInfo);
+		if (taskStatus != TaskStatus.SUCCEEDED) {
+			throw new TaskStatusException(taskStatus, "Failed to reset index settings.");
+		}
+
+		return getSettings();
 	}
 
 	private TaskStatus waitForTask(TaskInfo taskInfo) {

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchIndexOperations.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchIndexOperations.java
@@ -81,4 +81,26 @@ public interface MeilisearchIndexOperations {
 	 * @return index statistics
 	 */
 	MeilisearchIndexStats stats();
+
+	/**
+	 * Return runtime settings for the bound index.
+	 *
+	 * @return index settings
+	 */
+	MeilisearchIndexSettings getSettings();
+
+	/**
+	 * Update runtime settings for the bound index.
+	 *
+	 * @param settings index settings to update
+	 * @return index settings after the update task succeeds
+	 */
+	MeilisearchIndexSettings updateSettings(MeilisearchIndexSettings settings);
+
+	/**
+	 * Reset all runtime settings for the bound index to Meilisearch defaults.
+	 *
+	 * @return index settings after the reset task succeeds
+	 */
+	MeilisearchIndexSettings resetSettings();
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchIndexSettings.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchIndexSettings.java
@@ -1,0 +1,707 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.core;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Runtime settings for a Meilisearch index.
+ *
+ * @author Junghoon Ban
+ */
+public class MeilisearchIndexSettings {
+
+	@Nullable private final List<String> searchableAttributes;
+	@Nullable private final List<String> displayedAttributes;
+	@Nullable private final List<String> sortableAttributes;
+	@Nullable private final List<String> rankingRules;
+	@Nullable private final String distinctAttribute;
+	@Nullable private final List<String> filterableAttributes;
+	@Nullable private final Map<String, List<String>> synonyms;
+	@Nullable private final List<String> stopWords;
+	@Nullable private final List<String> dictionary;
+	@Nullable private final PaginationSettings pagination;
+	@Nullable private final FacetingSettings faceting;
+	@Nullable private final TypoToleranceSettings typoTolerance;
+	@Nullable private final String proximityPrecision;
+	@Nullable private final Integer searchCutoffMs;
+	@Nullable private final List<String> separatorTokens;
+	@Nullable private final List<String> nonSeparatorTokens;
+	@Nullable private final List<LocalizedAttributeSettings> localizedAttributes;
+	@Nullable private final Map<String, EmbedderSettings> embedders;
+
+	private MeilisearchIndexSettings(Builder builder) {
+
+		this.searchableAttributes = copyList(builder.searchableAttributes);
+		this.displayedAttributes = copyList(builder.displayedAttributes);
+		this.sortableAttributes = copyList(builder.sortableAttributes);
+		this.rankingRules = copyList(builder.rankingRules);
+		this.distinctAttribute = builder.distinctAttribute;
+		this.filterableAttributes = copyList(builder.filterableAttributes);
+		this.synonyms = copyListMap(builder.synonyms);
+		this.stopWords = copyList(builder.stopWords);
+		this.dictionary = copyList(builder.dictionary);
+		this.pagination = builder.pagination;
+		this.faceting = builder.faceting;
+		this.typoTolerance = builder.typoTolerance;
+		this.proximityPrecision = builder.proximityPrecision;
+		this.searchCutoffMs = builder.searchCutoffMs;
+		this.separatorTokens = copyList(builder.separatorTokens);
+		this.nonSeparatorTokens = copyList(builder.nonSeparatorTokens);
+		this.localizedAttributes = copyList(builder.localizedAttributes);
+		this.embedders = copyMap(builder.embedders);
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	@Nullable
+	public List<String> getSearchableAttributes() {
+		return searchableAttributes;
+	}
+
+	@Nullable
+	public List<String> getDisplayedAttributes() {
+		return displayedAttributes;
+	}
+
+	@Nullable
+	public List<String> getSortableAttributes() {
+		return sortableAttributes;
+	}
+
+	@Nullable
+	public List<String> getRankingRules() {
+		return rankingRules;
+	}
+
+	@Nullable
+	public String getDistinctAttribute() {
+		return distinctAttribute;
+	}
+
+	@Nullable
+	public List<String> getFilterableAttributes() {
+		return filterableAttributes;
+	}
+
+	@Nullable
+	public Map<String, List<String>> getSynonyms() {
+		return synonyms;
+	}
+
+	@Nullable
+	public List<String> getStopWords() {
+		return stopWords;
+	}
+
+	@Nullable
+	public List<String> getDictionary() {
+		return dictionary;
+	}
+
+	@Nullable
+	public PaginationSettings getPagination() {
+		return pagination;
+	}
+
+	@Nullable
+	public FacetingSettings getFaceting() {
+		return faceting;
+	}
+
+	@Nullable
+	public TypoToleranceSettings getTypoTolerance() {
+		return typoTolerance;
+	}
+
+	@Nullable
+	public String getProximityPrecision() {
+		return proximityPrecision;
+	}
+
+	@Nullable
+	public Integer getSearchCutoffMs() {
+		return searchCutoffMs;
+	}
+
+	@Nullable
+	public List<String> getSeparatorTokens() {
+		return separatorTokens;
+	}
+
+	@Nullable
+	public List<String> getNonSeparatorTokens() {
+		return nonSeparatorTokens;
+	}
+
+	@Nullable
+	public List<LocalizedAttributeSettings> getLocalizedAttributes() {
+		return localizedAttributes;
+	}
+
+	@Nullable
+	public Map<String, EmbedderSettings> getEmbedders() {
+		return embedders;
+	}
+
+	@Nullable
+	private static <T> List<T> copyList(@Nullable List<T> source) {
+		return source != null ? List.copyOf(source) : null;
+	}
+
+	@Nullable
+	private static <T> Map<String, T> copyMap(@Nullable Map<String, T> source) {
+		return source != null ? Map.copyOf(source) : null;
+	}
+
+	@Nullable
+	private static Map<String, List<String>> copyListMap(@Nullable Map<String, List<String>> source) {
+
+		if (source == null) {
+			return null;
+		}
+
+		Map<String, List<String>> copy = new LinkedHashMap<>();
+		source.forEach((key, value) -> copy.put(key, List.copyOf(value)));
+		return Map.copyOf(copy);
+	}
+
+	/** Builder for {@link MeilisearchIndexSettings}. */
+	public static class Builder {
+
+		@Nullable private List<String> searchableAttributes;
+		@Nullable private List<String> displayedAttributes;
+		@Nullable private List<String> sortableAttributes;
+		@Nullable private List<String> rankingRules;
+		@Nullable private String distinctAttribute;
+		@Nullable private List<String> filterableAttributes;
+		@Nullable private Map<String, List<String>> synonyms;
+		@Nullable private List<String> stopWords;
+		@Nullable private List<String> dictionary;
+		@Nullable private PaginationSettings pagination;
+		@Nullable private FacetingSettings faceting;
+		@Nullable private TypoToleranceSettings typoTolerance;
+		@Nullable private String proximityPrecision;
+		@Nullable private Integer searchCutoffMs;
+		@Nullable private List<String> separatorTokens;
+		@Nullable private List<String> nonSeparatorTokens;
+		@Nullable private List<LocalizedAttributeSettings> localizedAttributes;
+		@Nullable private Map<String, EmbedderSettings> embedders;
+
+		public Builder withSearchableAttributes(List<String> searchableAttributes) {
+
+			Assert.notNull(searchableAttributes, "Searchable attributes must not be null");
+			this.searchableAttributes = searchableAttributes;
+			return this;
+		}
+
+		public Builder withDisplayedAttributes(List<String> displayedAttributes) {
+
+			Assert.notNull(displayedAttributes, "Displayed attributes must not be null");
+			this.displayedAttributes = displayedAttributes;
+			return this;
+		}
+
+		public Builder withSortableAttributes(List<String> sortableAttributes) {
+
+			Assert.notNull(sortableAttributes, "Sortable attributes must not be null");
+			this.sortableAttributes = sortableAttributes;
+			return this;
+		}
+
+		public Builder withRankingRules(List<String> rankingRules) {
+
+			Assert.notNull(rankingRules, "Ranking rules must not be null");
+			this.rankingRules = rankingRules;
+			return this;
+		}
+
+		public Builder withDistinctAttribute(@Nullable String distinctAttribute) {
+
+			this.distinctAttribute = distinctAttribute;
+			return this;
+		}
+
+		public Builder withFilterableAttributes(List<String> filterableAttributes) {
+
+			Assert.notNull(filterableAttributes, "Filterable attributes must not be null");
+			this.filterableAttributes = filterableAttributes;
+			return this;
+		}
+
+		public Builder withSynonyms(Map<String, List<String>> synonyms) {
+
+			Assert.notNull(synonyms, "Synonyms must not be null");
+			this.synonyms = synonyms;
+			return this;
+		}
+
+		public Builder withStopWords(List<String> stopWords) {
+
+			Assert.notNull(stopWords, "Stop words must not be null");
+			this.stopWords = stopWords;
+			return this;
+		}
+
+		public Builder withDictionary(List<String> dictionary) {
+
+			Assert.notNull(dictionary, "Dictionary must not be null");
+			this.dictionary = dictionary;
+			return this;
+		}
+
+		public Builder withPagination(PaginationSettings pagination) {
+
+			Assert.notNull(pagination, "Pagination settings must not be null");
+			this.pagination = pagination;
+			return this;
+		}
+
+		public Builder withFaceting(FacetingSettings faceting) {
+
+			Assert.notNull(faceting, "Faceting settings must not be null");
+			this.faceting = faceting;
+			return this;
+		}
+
+		public Builder withTypoTolerance(TypoToleranceSettings typoTolerance) {
+
+			Assert.notNull(typoTolerance, "Typo tolerance settings must not be null");
+			this.typoTolerance = typoTolerance;
+			return this;
+		}
+
+		public Builder withProximityPrecision(@Nullable String proximityPrecision) {
+
+			this.proximityPrecision = proximityPrecision;
+			return this;
+		}
+
+		public Builder withSearchCutoffMs(@Nullable Integer searchCutoffMs) {
+
+			this.searchCutoffMs = searchCutoffMs;
+			return this;
+		}
+
+		public Builder withSeparatorTokens(List<String> separatorTokens) {
+
+			Assert.notNull(separatorTokens, "Separator tokens must not be null");
+			this.separatorTokens = separatorTokens;
+			return this;
+		}
+
+		public Builder withNonSeparatorTokens(List<String> nonSeparatorTokens) {
+
+			Assert.notNull(nonSeparatorTokens, "Non-separator tokens must not be null");
+			this.nonSeparatorTokens = nonSeparatorTokens;
+			return this;
+		}
+
+		public Builder withLocalizedAttributes(List<LocalizedAttributeSettings> localizedAttributes) {
+
+			Assert.notNull(localizedAttributes, "Localized attributes must not be null");
+			this.localizedAttributes = localizedAttributes;
+			return this;
+		}
+
+		public Builder withEmbedders(Map<String, EmbedderSettings> embedders) {
+
+			Assert.notNull(embedders, "Embedders must not be null");
+			this.embedders = embedders;
+			return this;
+		}
+
+		public MeilisearchIndexSettings build() {
+			return new MeilisearchIndexSettings(this);
+		}
+	}
+
+	/** Pagination runtime settings. */
+	public static class PaginationSettings {
+
+		private final int maxTotalHits;
+
+		public PaginationSettings(int maxTotalHits) {
+			this.maxTotalHits = maxTotalHits;
+		}
+
+		public int getMaxTotalHits() {
+			return maxTotalHits;
+		}
+	}
+
+	/** Faceting runtime settings. */
+	public static class FacetingSettings {
+
+		private final int maxValuesPerFacet;
+
+		public FacetingSettings(int maxValuesPerFacet) {
+			this.maxValuesPerFacet = maxValuesPerFacet;
+		}
+
+		public int getMaxValuesPerFacet() {
+			return maxValuesPerFacet;
+		}
+	}
+
+	/** Typo tolerance runtime settings. */
+	public static class TypoToleranceSettings {
+
+		private final boolean enabled;
+		@Nullable private final Integer oneTypo;
+		@Nullable private final Integer twoTypos;
+		@Nullable private final List<String> disableOnWords;
+		@Nullable private final List<String> disableOnAttributes;
+
+		public TypoToleranceSettings(boolean enabled, @Nullable Integer oneTypo, @Nullable Integer twoTypos,
+				@Nullable List<String> disableOnWords, @Nullable List<String> disableOnAttributes) {
+
+			this.enabled = enabled;
+			this.oneTypo = oneTypo;
+			this.twoTypos = twoTypos;
+			this.disableOnWords = copyList(disableOnWords);
+			this.disableOnAttributes = copyList(disableOnAttributes);
+		}
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		@Nullable
+		public Integer getOneTypo() {
+			return oneTypo;
+		}
+
+		@Nullable
+		public Integer getTwoTypos() {
+			return twoTypos;
+		}
+
+		@Nullable
+		public List<String> getDisableOnWords() {
+			return disableOnWords;
+		}
+
+		@Nullable
+		public List<String> getDisableOnAttributes() {
+			return disableOnAttributes;
+		}
+
+	}
+
+	/** Localized attribute runtime settings. */
+	public static class LocalizedAttributeSettings {
+
+		private final List<String> attributePatterns;
+		private final List<String> locales;
+
+		public LocalizedAttributeSettings(List<String> attributePatterns, List<String> locales) {
+
+			Assert.notNull(attributePatterns, "Attribute patterns must not be null");
+			Assert.notNull(locales, "Locales must not be null");
+			this.attributePatterns = List.copyOf(attributePatterns);
+			this.locales = List.copyOf(locales);
+		}
+
+		public List<String> getAttributePatterns() {
+			return attributePatterns;
+		}
+
+		public List<String> getLocales() {
+			return locales;
+		}
+	}
+
+	/** Embedder source values supported by Meilisearch. */
+	public enum EmbedderSource {
+
+		OPEN_AI, HUGGING_FACE, OLLAMA, REST, USER_PROVIDED
+	}
+
+	/** Embedder input type values supported by Meilisearch. */
+	public enum EmbedderInputType {
+
+		TEXT, TEXT_ARRAY
+	}
+
+	/** Embedder distribution runtime settings. */
+	public static class EmbedderDistributionSettings {
+
+		@Nullable private final Double mean;
+		@Nullable private final Double sigma;
+
+		public EmbedderDistributionSettings(@Nullable Double mean, @Nullable Double sigma) {
+
+			this.mean = mean;
+			this.sigma = sigma;
+		}
+
+		@Nullable
+		public Double getMean() {
+			return mean;
+		}
+
+		@Nullable
+		public Double getSigma() {
+			return sigma;
+		}
+	}
+
+	/** Embedder runtime settings. */
+	public static class EmbedderSettings {
+
+		@Nullable private final EmbedderSource source;
+		@Nullable private final String apiKey;
+		@Nullable private final String model;
+		@Nullable private final String documentTemplate;
+		@Nullable private final Integer dimensions;
+		@Nullable private final EmbedderDistributionSettings distribution;
+		@Nullable private final Map<String, Object> request;
+		@Nullable private final Map<String, Object> response;
+		@Nullable private final Integer documentTemplateMaxBytes;
+		@Nullable private final String revision;
+		@Nullable private final Map<String, String> headers;
+		@Nullable private final Boolean binaryQuantized;
+		@Nullable private final String url;
+		@Nullable private final List<String> inputField;
+		@Nullable private final EmbedderInputType inputType;
+		@Nullable private final String query;
+
+		private EmbedderSettings(EmbedderBuilder builder) {
+
+			this.source = builder.source;
+			this.apiKey = builder.apiKey;
+			this.model = builder.model;
+			this.documentTemplate = builder.documentTemplate;
+			this.dimensions = builder.dimensions;
+			this.distribution = builder.distribution;
+			this.request = copyMap(builder.request);
+			this.response = copyMap(builder.response);
+			this.documentTemplateMaxBytes = builder.documentTemplateMaxBytes;
+			this.revision = builder.revision;
+			this.headers = copyMap(builder.headers);
+			this.binaryQuantized = builder.binaryQuantized;
+			this.url = builder.url;
+			this.inputField = copyList(builder.inputField);
+			this.inputType = builder.inputType;
+			this.query = builder.query;
+		}
+
+		public static EmbedderBuilder builder() {
+			return new EmbedderBuilder();
+		}
+
+		@Nullable
+		public EmbedderSource getSource() {
+			return source;
+		}
+
+		@Nullable
+		public String getApiKey() {
+			return apiKey;
+		}
+
+		@Nullable
+		public String getModel() {
+			return model;
+		}
+
+		@Nullable
+		public String getDocumentTemplate() {
+			return documentTemplate;
+		}
+
+		@Nullable
+		public Integer getDimensions() {
+			return dimensions;
+		}
+
+		@Nullable
+		public EmbedderDistributionSettings getDistribution() {
+			return distribution;
+		}
+
+		@Nullable
+		public Map<String, Object> getRequest() {
+			return request;
+		}
+
+		@Nullable
+		public Map<String, Object> getResponse() {
+			return response;
+		}
+
+		@Nullable
+		public Integer getDocumentTemplateMaxBytes() {
+			return documentTemplateMaxBytes;
+		}
+
+		@Nullable
+		public String getRevision() {
+			return revision;
+		}
+
+		@Nullable
+		public Map<String, String> getHeaders() {
+			return headers;
+		}
+
+		@Nullable
+		public Boolean getBinaryQuantized() {
+			return binaryQuantized;
+		}
+
+		@Nullable
+		public String getUrl() {
+			return url;
+		}
+
+		@Nullable
+		public List<String> getInputField() {
+			return inputField;
+		}
+
+		@Nullable
+		public EmbedderInputType getInputType() {
+			return inputType;
+		}
+
+		@Nullable
+		public String getQuery() {
+			return query;
+		}
+
+		/** Builder for {@link EmbedderSettings}. */
+		public static class EmbedderBuilder {
+
+			@Nullable private EmbedderSource source;
+			@Nullable private String apiKey;
+			@Nullable private String model;
+			@Nullable private String documentTemplate;
+			@Nullable private Integer dimensions;
+			@Nullable private EmbedderDistributionSettings distribution;
+			@Nullable private Map<String, Object> request;
+			@Nullable private Map<String, Object> response;
+			@Nullable private Integer documentTemplateMaxBytes;
+			@Nullable private String revision;
+			@Nullable private Map<String, String> headers;
+			@Nullable private Boolean binaryQuantized;
+			@Nullable private String url;
+			@Nullable private List<String> inputField;
+			@Nullable private EmbedderInputType inputType;
+			@Nullable private String query;
+
+			public EmbedderBuilder withSource(@Nullable EmbedderSource source) {
+				this.source = source;
+				return this;
+			}
+
+			public EmbedderBuilder withApiKey(@Nullable String apiKey) {
+				this.apiKey = apiKey;
+				return this;
+			}
+
+			public EmbedderBuilder withModel(@Nullable String model) {
+				this.model = model;
+				return this;
+			}
+
+			public EmbedderBuilder withDocumentTemplate(@Nullable String documentTemplate) {
+				this.documentTemplate = documentTemplate;
+				return this;
+			}
+
+			public EmbedderBuilder withDimensions(@Nullable Integer dimensions) {
+				this.dimensions = dimensions;
+				return this;
+			}
+
+			public EmbedderBuilder withDistribution(@Nullable EmbedderDistributionSettings distribution) {
+				this.distribution = distribution;
+				return this;
+			}
+
+			public EmbedderBuilder withRequest(Map<String, Object> request) {
+
+				Assert.notNull(request, "Request parameters must not be null");
+				this.request = request;
+				return this;
+			}
+
+			public EmbedderBuilder withResponse(Map<String, Object> response) {
+
+				Assert.notNull(response, "Response parameters must not be null");
+				this.response = response;
+				return this;
+			}
+
+			public EmbedderBuilder withDocumentTemplateMaxBytes(@Nullable Integer documentTemplateMaxBytes) {
+				this.documentTemplateMaxBytes = documentTemplateMaxBytes;
+				return this;
+			}
+
+			public EmbedderBuilder withRevision(@Nullable String revision) {
+				this.revision = revision;
+				return this;
+			}
+
+			public EmbedderBuilder withHeaders(Map<String, String> headers) {
+
+				Assert.notNull(headers, "Headers must not be null");
+				this.headers = headers;
+				return this;
+			}
+
+			public EmbedderBuilder withBinaryQuantized(@Nullable Boolean binaryQuantized) {
+				this.binaryQuantized = binaryQuantized;
+				return this;
+			}
+
+			public EmbedderBuilder withUrl(@Nullable String url) {
+				this.url = url;
+				return this;
+			}
+
+			public EmbedderBuilder withInputField(List<String> inputField) {
+
+				Assert.notNull(inputField, "Input fields must not be null");
+				this.inputField = inputField;
+				return this;
+			}
+
+			public EmbedderBuilder withInputType(@Nullable EmbedderInputType inputType) {
+				this.inputType = inputType;
+				return this;
+			}
+
+			public EmbedderBuilder withQuery(@Nullable String query) {
+				this.query = query;
+				return this;
+			}
+
+			public EmbedderSettings build() {
+				return new EmbedderSettings(this);
+			}
+		}
+	}
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchIndexSettings.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/MeilisearchIndexSettings.java
@@ -299,6 +299,7 @@ public class MeilisearchIndexSettings {
 
 		public Builder withSearchCutoffMs(@Nullable Integer searchCutoffMs) {
 
+			Assert.isTrue(searchCutoffMs == null || searchCutoffMs >= 0, "Search cutoff ms must not be negative");
 			this.searchCutoffMs = searchCutoffMs;
 			return this;
 		}
@@ -342,6 +343,8 @@ public class MeilisearchIndexSettings {
 		private final int maxTotalHits;
 
 		public PaginationSettings(int maxTotalHits) {
+
+			Assert.isTrue(maxTotalHits >= 0, "Max total hits must not be negative");
 			this.maxTotalHits = maxTotalHits;
 		}
 
@@ -356,6 +359,8 @@ public class MeilisearchIndexSettings {
 		private final int maxValuesPerFacet;
 
 		public FacetingSettings(int maxValuesPerFacet) {
+
+			Assert.isTrue(maxValuesPerFacet >= 0, "Max values per facet must not be negative");
 			this.maxValuesPerFacet = maxValuesPerFacet;
 		}
 

--- a/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/IndexRequestConverterUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/IndexRequestConverterUnitTests.java
@@ -17,7 +17,6 @@ package io.vanslog.spring.data.meilisearch.client.msc;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -119,49 +118,4 @@ class IndexRequestConverterUnitTests {
 		assertThat(sdkSettings.getEmbedders().get("default").getBinaryQuantized()).isTrue();
 	}
 
-	@Test
-	void shouldConvertSdkSettingsToIndexSettings() {
-
-		Settings sdkSettings = new Settings();
-		sdkSettings.setSearchableAttributes(new String[] { "title", "description" });
-		sdkSettings.setDisplayedAttributes(new String[] { "id", "title" });
-		sdkSettings.setFilterableAttributes(new String[] { "genres" });
-		HashMap<String, String[]> synonyms = new HashMap<>();
-		synonyms.put("hero", new String[] { "superhero" });
-		sdkSettings.setSynonyms(synonyms);
-		sdkSettings.setPagination(new com.meilisearch.sdk.model.Pagination(1500));
-		com.meilisearch.sdk.model.Faceting faceting = new com.meilisearch.sdk.model.Faceting();
-		faceting.setMaxValuesPerFacet(75);
-		sdkSettings.setFaceting(faceting);
-		com.meilisearch.sdk.model.TypoTolerance typoTolerance = new com.meilisearch.sdk.model.TypoTolerance();
-		typoTolerance.setEnabled(true);
-		HashMap<String, Integer> minWordSizeForTypos = new HashMap<>();
-		minWordSizeForTypos.put("oneTypo", 5);
-		minWordSizeForTypos.put("twoTypos", 9);
-		typoTolerance.setMinWordSizeForTypos(minWordSizeForTypos);
-		sdkSettings.setTypoTolerance(typoTolerance);
-		sdkSettings.setLocalizedAttributes(new com.meilisearch.sdk.model.LocalizedAttribute[] {
-				new com.meilisearch.sdk.model.LocalizedAttribute(new String[] { "title_*" }, new String[] { "eng" }) });
-		HashMap<String, com.meilisearch.sdk.model.Embedder> embedders = new HashMap<>();
-		embedders.put("default", new com.meilisearch.sdk.model.Embedder()
-				.setSource(com.meilisearch.sdk.model.EmbedderSource.REST).setUrl("https://example.com/embed")
-				.setInputType(com.meilisearch.sdk.model.EmbedderInputType.TEXT_ARRAY));
-		sdkSettings.setEmbedders(embedders);
-
-		MeilisearchIndexSettings settings = converter.fromSettings(sdkSettings);
-
-		assertThat(settings.getSearchableAttributes()).containsExactly("title", "description");
-		assertThat(settings.getDisplayedAttributes()).containsExactly("id", "title");
-		assertThat(settings.getFilterableAttributes()).containsExactly("genres");
-		assertThat(settings.getSynonyms()).containsEntry("hero", List.of("superhero"));
-		assertThat(settings.getPagination().getMaxTotalHits()).isEqualTo(1500);
-		assertThat(settings.getFaceting().getMaxValuesPerFacet()).isEqualTo(75);
-		assertThat(settings.getTypoTolerance().getOneTypo()).isEqualTo(5);
-		assertThat(settings.getTypoTolerance().getTwoTypos()).isEqualTo(9);
-		assertThat(settings.getLocalizedAttributes().get(0).getAttributePatterns()).containsExactly("title_*");
-		assertThat(settings.getLocalizedAttributes().get(0).getLocales()).containsExactly("eng");
-		assertThat(settings.getEmbedders().get("default").getSource()).isEqualTo(EmbedderSource.REST);
-		assertThat(settings.getEmbedders().get("default").getUrl()).isEqualTo("https://example.com/embed");
-		assertThat(settings.getEmbedders().get("default").getInputType()).isEqualTo(EmbedderInputType.TEXT_ARRAY);
-	}
 }

--- a/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/IndexRequestConverterUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/IndexRequestConverterUnitTests.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.client.msc;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.meilisearch.sdk.model.Settings;
+
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderDistributionSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderInputType;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderSource;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.FacetingSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.LocalizedAttributeSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.PaginationSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.TypoToleranceSettings;
+
+/**
+ * Unit tests for {@link IndexRequestConverter}.
+ *
+ * @author Junghoon Ban
+ */
+class IndexRequestConverterUnitTests {
+
+	private final IndexRequestConverter converter = new IndexRequestConverter();
+
+	@Test
+	void shouldConvertIndexSettingsToSdkSettings() {
+
+		MeilisearchIndexSettings settings = MeilisearchIndexSettings.builder() //
+				.withSearchableAttributes(List.of("title", "description")) //
+				.withDisplayedAttributes(List.of("id", "title")) //
+				.withSortableAttributes(List.of("title")) //
+				.withRankingRules(List.of("words", "typo")) //
+				.withDistinctAttribute("title") //
+				.withFilterableAttributes(List.of("genres")) //
+				.withSynonyms(Map.of("hero", List.of("superhero"))) //
+				.withStopWords(List.of("the")) //
+				.withDictionary(List.of("meilisearch")) //
+				.withPagination(new PaginationSettings(1500)) //
+				.withFaceting(new FacetingSettings(75)) //
+				.withTypoTolerance(new TypoToleranceSettings(true, 5, 9, List.of("skype"),
+						List.of("serial_number"))) //
+				.withProximityPrecision("byWord") //
+				.withSearchCutoffMs(50) //
+				.withSeparatorTokens(List.of("-")) //
+				.withNonSeparatorTokens(List.of(".")) //
+				.withLocalizedAttributes(List.of(new LocalizedAttributeSettings(List.of("title_*"), List.of("eng")))) //
+				.withEmbedders(Map.of("default", EmbedderSettings.builder() //
+						.withSource(EmbedderSource.REST) //
+						.withUrl("https://example.com/embed") //
+						.withInputField(List.of("title")) //
+						.withInputType(EmbedderInputType.TEXT_ARRAY) //
+						.withDistribution(new EmbedderDistributionSettings(0.5, 0.25)) //
+						.withRequest(Map.of("text", "{{text}}")) //
+						.withResponse(Map.of("embedding", "$.embedding")) //
+						.withHeaders(Map.of("Authorization", "Bearer token")) //
+						.withBinaryQuantized(true) //
+						.build())) //
+				.build();
+
+		Settings sdkSettings = converter.toSettings(settings);
+
+		assertThat(sdkSettings.getSearchableAttributes()).containsExactly("title", "description");
+		assertThat(sdkSettings.getDisplayedAttributes()).containsExactly("id", "title");
+		assertThat(sdkSettings.getSortableAttributes()).containsExactly("title");
+		assertThat(sdkSettings.getRankingRules()).containsExactly("words", "typo");
+		assertThat(sdkSettings.getDistinctAttribute()).isEqualTo("title");
+		assertThat(sdkSettings.getFilterableAttributes()).containsExactly("genres");
+		assertThat(sdkSettings.getSynonyms()).containsKey("hero");
+		assertThat(sdkSettings.getSynonyms().get("hero")).containsExactly("superhero");
+		assertThat(sdkSettings.getStopWords()).containsExactly("the");
+		assertThat(sdkSettings.getDictionary()).containsExactly("meilisearch");
+		assertThat(sdkSettings.getPagination().getMaxTotalHits()).isEqualTo(1500);
+		assertThat(sdkSettings.getFaceting().getMaxValuesPerFacet()).isEqualTo(75);
+		assertThat(sdkSettings.getTypoTolerance().isEnabled()).isTrue();
+		assertThat(sdkSettings.getTypoTolerance().getMinWordSizeForTypos()).containsEntry("oneTypo", 5)
+				.containsEntry("twoTypos", 9);
+		assertThat(sdkSettings.getTypoTolerance().getDisableOnWords()).containsExactly("skype");
+		assertThat(sdkSettings.getTypoTolerance().getDisableOnAttributes()).containsExactly("serial_number");
+		assertThat(sdkSettings.getProximityPrecision()).isEqualTo("byWord");
+		assertThat(sdkSettings.getSearchCutoffMs()).isEqualTo(50);
+		assertThat(sdkSettings.getSeparatorTokens()).containsExactly("-");
+		assertThat(sdkSettings.getNonSeparatorTokens()).containsExactly(".");
+		assertThat(sdkSettings.getLocalizedAttributes()[0].getAttributePatterns()).containsExactly("title_*");
+		assertThat(sdkSettings.getLocalizedAttributes()[0].getLocales()).containsExactly("eng");
+		assertThat(sdkSettings.getEmbedders().get("default").getSource())
+				.isEqualTo(com.meilisearch.sdk.model.EmbedderSource.REST);
+		assertThat(sdkSettings.getEmbedders().get("default").getUrl()).isEqualTo("https://example.com/embed");
+		assertThat(sdkSettings.getEmbedders().get("default").getInputField()).containsExactly("title");
+		assertThat(sdkSettings.getEmbedders().get("default").getInputType())
+				.isEqualTo(com.meilisearch.sdk.model.EmbedderInputType.TEXT_ARRAY);
+		assertThat(sdkSettings.getEmbedders().get("default").getDistribution().getMean()).isEqualTo(0.5);
+		assertThat(sdkSettings.getEmbedders().get("default").getDistribution().getSigma()).isEqualTo(0.25);
+		assertThat(sdkSettings.getEmbedders().get("default").getRequest()).containsEntry("text", "{{text}}");
+		assertThat(sdkSettings.getEmbedders().get("default").getResponse()).containsEntry("embedding", "$.embedding");
+		assertThat(sdkSettings.getEmbedders().get("default").getHeaders())
+				.containsEntry("Authorization", "Bearer token");
+		assertThat(sdkSettings.getEmbedders().get("default").getBinaryQuantized()).isTrue();
+	}
+
+	@Test
+	void shouldConvertSdkSettingsToIndexSettings() {
+
+		Settings sdkSettings = new Settings();
+		sdkSettings.setSearchableAttributes(new String[] { "title", "description" });
+		sdkSettings.setDisplayedAttributes(new String[] { "id", "title" });
+		sdkSettings.setFilterableAttributes(new String[] { "genres" });
+		HashMap<String, String[]> synonyms = new HashMap<>();
+		synonyms.put("hero", new String[] { "superhero" });
+		sdkSettings.setSynonyms(synonyms);
+		sdkSettings.setPagination(new com.meilisearch.sdk.model.Pagination(1500));
+		com.meilisearch.sdk.model.Faceting faceting = new com.meilisearch.sdk.model.Faceting();
+		faceting.setMaxValuesPerFacet(75);
+		sdkSettings.setFaceting(faceting);
+		com.meilisearch.sdk.model.TypoTolerance typoTolerance = new com.meilisearch.sdk.model.TypoTolerance();
+		typoTolerance.setEnabled(true);
+		HashMap<String, Integer> minWordSizeForTypos = new HashMap<>();
+		minWordSizeForTypos.put("oneTypo", 5);
+		minWordSizeForTypos.put("twoTypos", 9);
+		typoTolerance.setMinWordSizeForTypos(minWordSizeForTypos);
+		sdkSettings.setTypoTolerance(typoTolerance);
+		sdkSettings.setLocalizedAttributes(new com.meilisearch.sdk.model.LocalizedAttribute[] {
+				new com.meilisearch.sdk.model.LocalizedAttribute(new String[] { "title_*" }, new String[] { "eng" }) });
+		HashMap<String, com.meilisearch.sdk.model.Embedder> embedders = new HashMap<>();
+		embedders.put("default", new com.meilisearch.sdk.model.Embedder()
+				.setSource(com.meilisearch.sdk.model.EmbedderSource.REST).setUrl("https://example.com/embed")
+				.setInputType(com.meilisearch.sdk.model.EmbedderInputType.TEXT_ARRAY));
+		sdkSettings.setEmbedders(embedders);
+
+		MeilisearchIndexSettings settings = converter.fromSettings(sdkSettings);
+
+		assertThat(settings.getSearchableAttributes()).containsExactly("title", "description");
+		assertThat(settings.getDisplayedAttributes()).containsExactly("id", "title");
+		assertThat(settings.getFilterableAttributes()).containsExactly("genres");
+		assertThat(settings.getSynonyms()).containsEntry("hero", List.of("superhero"));
+		assertThat(settings.getPagination().getMaxTotalHits()).isEqualTo(1500);
+		assertThat(settings.getFaceting().getMaxValuesPerFacet()).isEqualTo(75);
+		assertThat(settings.getTypoTolerance().getOneTypo()).isEqualTo(5);
+		assertThat(settings.getTypoTolerance().getTwoTypos()).isEqualTo(9);
+		assertThat(settings.getLocalizedAttributes().get(0).getAttributePatterns()).containsExactly("title_*");
+		assertThat(settings.getLocalizedAttributes().get(0).getLocales()).containsExactly("eng");
+		assertThat(settings.getEmbedders().get("default").getSource()).isEqualTo(EmbedderSource.REST);
+		assertThat(settings.getEmbedders().get("default").getUrl()).isEqualTo("https://example.com/embed");
+		assertThat(settings.getEmbedders().get("default").getInputType()).isEqualTo(EmbedderInputType.TEXT_ARRAY);
+	}
+}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/IndexSettingsResponseConverterUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/IndexSettingsResponseConverterUnitTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.client.msc;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.meilisearch.sdk.model.Settings;
+
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderInputType;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.EmbedderSource;
+
+/**
+ * Unit tests for {@link IndexSettingsResponseConverter}.
+ *
+ * @author Junghoon Ban
+ */
+class IndexSettingsResponseConverterUnitTests {
+
+	private final IndexSettingsResponseConverter converter = new IndexSettingsResponseConverter();
+
+	@Test
+	void shouldConvertSdkSettingsToIndexSettings() {
+
+		Settings sdkSettings = new Settings();
+		sdkSettings.setSearchableAttributes(new String[] { "title", "description" });
+		sdkSettings.setDisplayedAttributes(new String[] { "id", "title" });
+		sdkSettings.setFilterableAttributes(new String[] { "genres" });
+		HashMap<String, String[]> synonyms = new HashMap<>();
+		synonyms.put("hero", new String[] { "superhero" });
+		sdkSettings.setSynonyms(synonyms);
+		sdkSettings.setPagination(new com.meilisearch.sdk.model.Pagination(1500));
+		com.meilisearch.sdk.model.Faceting faceting = new com.meilisearch.sdk.model.Faceting();
+		faceting.setMaxValuesPerFacet(75);
+		sdkSettings.setFaceting(faceting);
+		com.meilisearch.sdk.model.TypoTolerance typoTolerance = new com.meilisearch.sdk.model.TypoTolerance();
+		typoTolerance.setEnabled(true);
+		HashMap<String, Integer> minWordSizeForTypos = new HashMap<>();
+		minWordSizeForTypos.put("oneTypo", 5);
+		minWordSizeForTypos.put("twoTypos", 9);
+		typoTolerance.setMinWordSizeForTypos(minWordSizeForTypos);
+		sdkSettings.setTypoTolerance(typoTolerance);
+		sdkSettings.setLocalizedAttributes(new com.meilisearch.sdk.model.LocalizedAttribute[] {
+				new com.meilisearch.sdk.model.LocalizedAttribute(new String[] { "title_*" }, new String[] { "eng" }) });
+		HashMap<String, com.meilisearch.sdk.model.Embedder> embedders = new HashMap<>();
+		embedders.put("default", new com.meilisearch.sdk.model.Embedder()
+				.setSource(com.meilisearch.sdk.model.EmbedderSource.REST).setUrl("https://example.com/embed")
+				.setInputType(com.meilisearch.sdk.model.EmbedderInputType.TEXT_ARRAY));
+		sdkSettings.setEmbedders(embedders);
+
+		MeilisearchIndexSettings settings = converter.fromSettings(sdkSettings);
+
+		assertThat(settings.getSearchableAttributes()).containsExactly("title", "description");
+		assertThat(settings.getDisplayedAttributes()).containsExactly("id", "title");
+		assertThat(settings.getFilterableAttributes()).containsExactly("genres");
+		assertThat(settings.getSynonyms()).containsEntry("hero", List.of("superhero"));
+		assertThat(settings.getPagination().getMaxTotalHits()).isEqualTo(1500);
+		assertThat(settings.getFaceting().getMaxValuesPerFacet()).isEqualTo(75);
+		assertThat(settings.getTypoTolerance().getOneTypo()).isEqualTo(5);
+		assertThat(settings.getTypoTolerance().getTwoTypos()).isEqualTo(9);
+		assertThat(settings.getLocalizedAttributes().get(0).getAttributePatterns()).containsExactly("title_*");
+		assertThat(settings.getLocalizedAttributes().get(0).getLocales()).containsExactly("eng");
+		assertThat(settings.getEmbedders().get("default").getSource()).isEqualTo(EmbedderSource.REST);
+		assertThat(settings.getEmbedders().get("default").getUrl()).isEqualTo("https://example.com/embed");
+		assertThat(settings.getEmbedders().get("default").getInputType()).isEqualTo(EmbedderInputType.TEXT_ARRAY);
+	}
+}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchIndexSettingsUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchIndexSettingsUnitTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.FacetingSettings;
+import io.vanslog.spring.data.meilisearch.core.MeilisearchIndexSettings.PaginationSettings;
+
+/**
+ * Unit tests for {@link MeilisearchIndexSettings}.
+ *
+ * @author Junghoon Ban
+ */
+class MeilisearchIndexSettingsUnitTests {
+
+	@Test
+	void shouldAllowNullSearchCutoffMs() {
+
+		MeilisearchIndexSettings settings = MeilisearchIndexSettings.builder().withSearchCutoffMs(null).build();
+
+		assertThat(settings.getSearchCutoffMs()).isNull();
+	}
+
+	@Test
+	void shouldAllowZeroNumericSettings() {
+
+		MeilisearchIndexSettings settings = MeilisearchIndexSettings.builder() //
+				.withSearchCutoffMs(0) //
+				.withPagination(new PaginationSettings(0)) //
+				.withFaceting(new FacetingSettings(0)) //
+				.build();
+
+		assertThat(settings.getSearchCutoffMs()).isZero();
+		assertThat(settings.getPagination().getMaxTotalHits()).isZero();
+		assertThat(settings.getFaceting().getMaxValuesPerFacet()).isZero();
+	}
+
+	@Test
+	void shouldRejectNegativeSearchCutoffMs() {
+
+		assertThatIllegalArgumentException() //
+				.isThrownBy(() -> MeilisearchIndexSettings.builder().withSearchCutoffMs(-1)) //
+				.withMessageContaining("Search cutoff ms must not be negative");
+	}
+
+	@Test
+	void shouldRejectNegativeMaxTotalHits() {
+
+		assertThatIllegalArgumentException() //
+				.isThrownBy(() -> new PaginationSettings(-1)) //
+				.withMessageContaining("Max total hits must not be negative");
+	}
+
+	@Test
+	void shouldRejectNegativeMaxValuesPerFacet() {
+
+		assertThatIllegalArgumentException() //
+				.isThrownBy(() -> new FacetingSettings(-1)) //
+				.withMessageContaining("Max values per facet must not be negative");
+	}
+
+}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateIntegrationTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateIntegrationTests.java
@@ -373,7 +373,7 @@ class MeilisearchTemplateIntegrationTests {
 
 		MeilisearchIndexSettings reset = indexOperations.resetSettings();
 
-		assertThat(reset.getFilterableAttributes()).doesNotContain("genres");
+		assertThat(reset.getFilterableAttributes()).isEmpty();
 	}
 
 	@Test

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateIntegrationTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateIntegrationTests.java
@@ -31,6 +31,7 @@ import io.vanslog.spring.data.meilisearch.junit.jupiter.MeilisearchTestConfigura
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,7 +66,8 @@ class MeilisearchTemplateIntegrationTests {
 	ComicsMovie comics2 = new ComicsMovie(2, "Batman", "A superhero comic", new String[] { "Comics", "Action" });
 
 	private static final List<String> LIFECYCLE_INDEX_UIDS = List.of("lifecycle-create-index",
-			"lifecycle-get-list-index", "lifecycle-update-index", "lifecycle-delete-index");
+			"lifecycle-get-list-index", "lifecycle-update-index", "lifecycle-delete-index", "runtime-settings-index",
+			"runtime-settings-reset-index");
 
 	@BeforeEach
 	void setUp() throws MeilisearchException {
@@ -311,6 +313,67 @@ class MeilisearchTemplateIntegrationTests {
 	void shouldRejectBlankIndexUid() {
 
 		assertThatIllegalArgumentException().isThrownBy(() -> meilisearchTemplate.indexOps(""));
+	}
+
+	@Test
+	void shouldReadCurrentIndexSettings() {
+
+		meilisearchTemplate.applySettings(Movie.class);
+
+		MeilisearchIndexSettings settings = meilisearchTemplate.indexOps(Movie.class).getSettings();
+
+		assertThat(settings.getFilterableAttributes()).contains("genres");
+	}
+
+	@Test
+	void shouldUpdateIndexSettings() {
+
+		meilisearchTemplate.indexOps("runtime-settings-index").create(new MeilisearchIndexCreateRequest("id"));
+		MeilisearchIndexSettings settings = MeilisearchIndexSettings.builder() //
+				.withSearchableAttributes(List.of("title", "description")) //
+				.withDisplayedAttributes(List.of("id", "title", "description")) //
+				.withFilterableAttributes(List.of("genres")) //
+				.withSortableAttributes(List.of("title")) //
+				.withSynonyms(Map.of("hero", List.of("superhero"))) //
+				.withPagination(new MeilisearchIndexSettings.PaginationSettings(1500)) //
+				.withFaceting(new MeilisearchIndexSettings.FacetingSettings(75)) //
+				.withTypoTolerance(new MeilisearchIndexSettings.TypoToleranceSettings(true, 5, 9,
+						List.of("skype"), List.of("serial_number"))) //
+				.withProximityPrecision("byWord") //
+				.withSearchCutoffMs(50) //
+				.build();
+
+		MeilisearchIndexSettings updated = meilisearchTemplate.indexOps("runtime-settings-index")
+				.updateSettings(settings);
+
+		assertThat(updated.getSearchableAttributes()).containsExactly("title", "description");
+		assertThat(updated.getDisplayedAttributes()).containsExactly("id", "title", "description");
+		assertThat(updated.getFilterableAttributes()).contains("genres");
+		assertThat(updated.getSortableAttributes()).contains("title");
+		assertThat(updated.getSynonyms()).containsEntry("hero", List.of("superhero"));
+		assertThat(updated.getPagination().getMaxTotalHits()).isEqualTo(1500);
+		assertThat(updated.getFaceting().getMaxValuesPerFacet()).isEqualTo(75);
+		assertThat(updated.getTypoTolerance().getOneTypo()).isEqualTo(5);
+		assertThat(updated.getTypoTolerance().getTwoTypos()).isEqualTo(9);
+		assertThat(updated.getTypoTolerance().getDisableOnWords()).containsExactly("skype");
+		assertThat(updated.getTypoTolerance().getDisableOnAttributes()).containsExactly("serial_number");
+		assertThat(updated.getProximityPrecision()).isEqualTo("byWord");
+		assertThat(updated.getSearchCutoffMs()).isEqualTo(50);
+	}
+
+	@Test
+	void shouldResetIndexSettings() {
+
+		meilisearchTemplate.indexOps("runtime-settings-reset-index").create(new MeilisearchIndexCreateRequest("id"));
+		MeilisearchIndexSettings settings = MeilisearchIndexSettings.builder() //
+				.withFilterableAttributes(List.of("genres")) //
+				.build();
+		MeilisearchIndexOperations indexOperations = meilisearchTemplate.indexOps("runtime-settings-reset-index");
+		assertThat(indexOperations.updateSettings(settings).getFilterableAttributes()).contains("genres");
+
+		MeilisearchIndexSettings reset = indexOperations.resetSettings();
+
+		assertThat(reset.getFilterableAttributes()).doesNotContain("genres");
 	}
 
 	@Test


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/junghoon-vans/spring-data-meilisearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #192

## Summary
- Add Spring Data-owned runtime index settings value types and SDK conversion.
- Add index-scoped settings read, update, and reset operations.
- Document runtime settings usage and relationship to annotation-driven applySettings.

## Stacked On
- #198

## Verification
- JAVA_HOME="$(/usr/libexec/java_home -v 17)" ./mvnw -Dtest=IndexRequestConverterUnitTests,MeilisearchTemplateIntegrationTests test
- JAVA_HOME="$(/usr/libexec/java_home -v 17)" ./mvnw test
- JAVA_HOME="$(/usr/libexec/java_home -v 17)" ./mvnw -Pantora antora:antora
- JAVA_HOME="$(/usr/libexec/java_home -v 17)" ./mvnw verify -Pci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added runtime index settings management: fetch current settings, update configuration (searchable/filterable attributes, synonyms, pagination, faceting, typo tolerance, embedders, etc.), and reset to defaults.

* **Documentation**
  - Updated documentation with examples for configuring settings via annotations and runtime operations.

* **Tests**
  - Added unit and integration tests validating settings operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/junghoon-vans/spring-data-meilisearch/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->