### PR TITLE
Improve release draft categorization.

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,6 +7,11 @@ categories:
     label: 'type: documentation'
   - title: '🔨 Dependency Upgrades'
     label: 'type: dependency-upgrade'
+  - title: '🧰 Maintenance'
+    label: 'type: task'
+
+exclude-contributors:
+  - 'junghoon-vans'
 
 change-template: '* $TITLE #$NUMBER'
 template: |

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,13 +2,13 @@ categories:
   - title: '⭐ New Features'
     label: 'type: enhancement'
   - title: '🐞 Bug Fixes'
-    label: 'type: bug'
+    labels:
+      - 'type: bug'
+      - 'type: regression'
   - title: '📔 Documentation'
     label: 'type: documentation'
   - title: '🔨 Dependency Upgrades'
     label: 'type: dependency-upgrade'
-  - title: '🧰 Maintenance'
-    label: 'type: task'
 
 exclude-contributors:
   - 'junghoon-vans'


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/junghoon-vans/spring-data-meilisearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #200

## Summary
- Fold `type: regression` into the Bug Fixes release-notes category to match Spring Data-style release categorization.
- Exclude `junghoon-vans` from generated contributors while keeping the contributors section enabled for other contributors.

## Verification
- `ruby -e 'require "yaml"; config = YAML.load_file(".github/release-drafter.yml"); raise "missing regression" unless config["categories"].any? { |c| c["title"].include?("Bug") && Array(c["labels"]).include?("type: regression") }; raise "task categorized" if config["categories"].any? { |c| c["label"] == "type: task" || Array(c["labels"]).include?("type: task") }; raise "missing exclusion" unless config["exclude-contributors"] == ["junghoon-vans"]; puts "valid"'`
