### PR TITLE
Upgrade testcontainers-meilisearch to v2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <meilisearch-java>0.20.1</meilisearch-java>
         <okhttp>5.3.2</okhttp>
         <kotlin-stdlib>2.2.21</kotlin-stdlib>
-        <testcontainers-meilisearch>1.1.0</testcontainers-meilisearch>
+        <testcontainers-meilisearch>2.0.0</testcontainers-meilisearch>
 
         <java-module-name>spring.data.meilisearch</java-module-name>
     </properties>


### PR DESCRIPTION
## Summary
- Upgrade `io.vanslog:testcontainers-meilisearch` from `1.1.0` to `2.0.0`.
- Keep `meilisearch-java` at `0.20.1` because it is already the latest available release.

## Verification
- `./mvnw -q test -DskipTests`
- `./mvnw -q -Dtest=MeilisearchTemplateIntegrationTests test`
- `./mvnw test` (105 tests)
- `./mvnw -q verify -Pci`

## Notes
- No tracker issue was provided for this dependency bump.