### PR TITLE
Add entity conversion foundation.

### DIFF
--- a/src/main/antora/modules/ROOT/pages/meilisearch/client-configuration.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch/client-configuration.adoc
@@ -49,6 +49,8 @@ These timeout and interval settings affect operations that submit asynchronous M
 == JSON Handler
 
 `MeilisearchConfiguration` registers `GsonJsonHandler` by default.
+The `JsonHandler` configures the underlying Meilisearch Java SDK transport.
+Entity document mapping and document JSON payloads are handled by Spring Data Meilisearch through `MeilisearchConverter` and the `meilisearchObjectMapper` bean.
 Override `jsonHandler()` when you need a different implementation.
 
 [source,java]

--- a/src/main/antora/modules/ROOT/pages/meilisearch/object-mapping.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch/object-mapping.adoc
@@ -80,6 +80,31 @@ Use xref:meilisearch/settings.adoc[runtime settings operations] when settings mu
 The default converter is `MappingMeilisearchConverter`.
 It uses the mapping context for entity metadata and applies any converters declared through `MeilisearchCustomConversions`.
 
+[[meilisearch.mapping.payloads]]
+== Document Mapping and JSON Payloads
+
+Spring Data Meilisearch maps entity instances through `MeilisearchConverter` before they reach the Meilisearch Java SDK.
+The default `MappingMeilisearchConverter` reads and writes a map-shaped `MeilisearchDocument`, applying the mapping metadata and custom conversions registered with `MeilisearchCustomConversions`.
+
+Document payloads are then serialized with the Spring-managed `ObjectMapper` bean named `meilisearchObjectMapper`.
+This keeps entity conversion in Spring Data Meilisearch and sends document requests through the SDK raw JSON APIs where the SDK exposes them.
+The SDK `JsonHandler` is still used for SDK transport concerns, but it is not the entity mapping layer.
+
+.Customizing the document ObjectMapper
+====
+[source,java]
+----
+@Configuration
+public class MyClientConfig extends MeilisearchConfiguration {
+
+	@Bean(name = "meilisearchObjectMapper")
+	public ObjectMapper meilisearchObjectMapper() {
+		return new ObjectMapper();
+	}
+}
+----
+====
+
 [[meilisearch.mapping.custom-conversions]]
 == Custom Conversions
 

--- a/src/main/antora/modules/ROOT/pages/meilisearch/object-mapping.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch/object-mapping.adoc
@@ -84,7 +84,7 @@ It uses the mapping context for entity metadata and applies any converters decla
 == Document Mapping and JSON Payloads
 
 Spring Data Meilisearch maps entity instances through `MeilisearchConverter` before they reach the Meilisearch Java SDK.
-The default `MappingMeilisearchConverter` reads and writes a map-shaped `MeilisearchDocument`, applying the mapping metadata and custom conversions registered with `MeilisearchCustomConversions`.
+The default `MappingMeilisearchConverter` reads and writes a map-shaped `Document`, applying the mapping metadata and custom conversions registered with `MeilisearchCustomConversions`.
 
 Document payloads are then serialized with the Spring-managed `ObjectMapper` bean named `meilisearchObjectMapper`.
 This keeps entity conversion in Spring Data Meilisearch and sends document requests through the SDK raw JSON APIs where the SDK exposes them.

--- a/src/main/antora/modules/ROOT/pages/repositories/configuration.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/configuration.adoc
@@ -56,10 +56,29 @@ However, Spring Data Meilisearch's documented repository model currently centers
 
     <meilisearch:meilisearch-client id="meilisearchClient" api-key="${MEILISEARCH_API_KEY}"/>
 
+    <bean id="meilisearchConverter"
+          class="io.vanslog.spring.data.meilisearch.core.convert.MappingMeilisearchConverter">
+        <constructor-arg name="mappingContext" ref="meilisearchMappingContext"/>
+        <property name="conversions" ref="meilisearchCustomConversions"/>
+    </bean>
+
+    <bean id="meilisearchMappingContext"
+          class="io.vanslog.spring.data.meilisearch.core.mapping.SimpleMeilisearchMappingContext"/>
+
+    <bean id="meilisearchCustomConversions"
+          class="io.vanslog.spring.data.meilisearch.core.convert.MeilisearchCustomConversions">
+        <constructor-arg>
+            <list/>
+        </constructor-arg>
+    </bean>
+
+    <bean id="meilisearchObjectMapper" class="com.fasterxml.jackson.databind.ObjectMapper"/>
+
     <bean id="meilisearchTemplate"
           class="io.vanslog.spring.data.meilisearch.client.msc.MeilisearchTemplate">
         <constructor-arg name="meilisearchClient" ref="meilisearchClient"/>
         <constructor-arg name="meilisearchConverter" ref="meilisearchConverter"/>
+        <constructor-arg name="objectMapper" ref="meilisearchObjectMapper"/>
     </bean>
 
     <meilisearch:repositories
@@ -70,3 +89,4 @@ However, Spring Data Meilisearch's documented repository model currently centers
 
 The XML namespace extends the Spring Data repository namespace and adds the `meilisearch-template-ref` attribute.
 See xref:appendix.adoc#meilisearch.appendix.schema[XML namespace reference] for the full attribute list.
+The manual `meilisearchTemplate` bean must be wired with a `MeilisearchConverter` for entity mapping and the `meilisearchObjectMapper` bean for JSON document payload serialization.

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchFacetSearchResult.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchFacetSearchResult.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.client.msc;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meilisearch.sdk.model.FacetSearchable;
+
+/**
+ * Raw facet search response adapter used after reading JSON responses from Meilisearch.
+ *
+ * @author Junghoon Ban
+ */
+final class MeilisearchFacetSearchResult implements FacetSearchable {
+
+	private final ArrayList<HashMap<String, Object>> facetHits;
+	private final int processingTimeMs;
+	private final String facetQuery;
+
+	private MeilisearchFacetSearchResult(ArrayList<HashMap<String, Object>> facetHits, int processingTimeMs,
+			String facetQuery) {
+
+		this.facetHits = facetHits;
+		this.processingTimeMs = processingTimeMs;
+		this.facetQuery = facetQuery;
+	}
+
+	static MeilisearchFacetSearchResult from(JsonNode source, ObjectMapper objectMapper) {
+		return new MeilisearchFacetSearchResult(readFacetHits(source, objectMapper),
+				source.path("processingTimeMs").asInt(), source.path("facetQuery").asText());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static ArrayList<HashMap<String, Object>> readFacetHits(JsonNode source, ObjectMapper objectMapper) {
+		return objectMapper.convertValue(source.path("facetHits"), ArrayList.class);
+	}
+
+	@Override
+	public ArrayList<HashMap<String, Object>> getFacetHits() {
+		return facetHits;
+	}
+
+	@Override
+	public int getProcessingTimeMs() {
+		return processingTimeMs;
+	}
+
+	@Override
+	public String getFacetQuery() {
+		return facetQuery;
+	}
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchSearchResult.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchSearchResult.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.client.msc;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import org.springframework.lang.Nullable;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meilisearch.sdk.model.FacetRating;
+import com.meilisearch.sdk.model.Searchable;
+
+/**
+ * Raw search response adapter used after reading JSON responses from Meilisearch.
+ *
+ * @author Junghoon Ban
+ */
+final class MeilisearchSearchResult implements Searchable {
+
+	private final ArrayList<HashMap<String, Object>> hits;
+	@Nullable private final Object facetDistribution;
+	@Nullable private final HashMap<String, FacetRating> facetStats;
+	private final int processingTimeMs;
+	private final String query;
+	@Nullable private final Integer totalHits;
+
+	private MeilisearchSearchResult(ArrayList<HashMap<String, Object>> hits, @Nullable Object facetDistribution,
+			@Nullable HashMap<String, FacetRating> facetStats, int processingTimeMs, String query,
+			@Nullable Integer totalHits) {
+
+		this.hits = hits;
+		this.facetDistribution = facetDistribution;
+		this.facetStats = facetStats;
+		this.processingTimeMs = processingTimeMs;
+		this.query = query;
+		this.totalHits = totalHits;
+	}
+
+	static MeilisearchSearchResult from(JsonNode source, ObjectMapper objectMapper) {
+
+		ArrayList<HashMap<String, Object>> hits = readHits(source, objectMapper);
+		Object facetDistribution = source.has("facetDistribution")
+				? objectMapper.convertValue(source.get("facetDistribution"), Object.class) : null;
+		HashMap<String, FacetRating> facetStats = readFacetStats(source, objectMapper);
+		Integer totalHits = source.has("totalHits") ? source.get("totalHits").asInt() : null;
+
+		return new MeilisearchSearchResult(hits, facetDistribution, facetStats,
+				source.path("processingTimeMs").asInt(), source.path("query").asText(), totalHits);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static ArrayList<HashMap<String, Object>> readHits(JsonNode source, ObjectMapper objectMapper) {
+		return objectMapper.convertValue(source.path("hits"), ArrayList.class);
+	}
+
+	@Nullable
+	private static HashMap<String, FacetRating> readFacetStats(JsonNode source, ObjectMapper objectMapper) {
+
+		if (!source.has("facetStats")) {
+			return null;
+		}
+
+		JavaType facetStatsType = objectMapper.getTypeFactory().constructMapType(HashMap.class, String.class,
+				FacetRating.class);
+		return objectMapper.convertValue(source.get("facetStats"), facetStatsType);
+	}
+
+	@Override
+	public ArrayList<HashMap<String, Object>> getHits() {
+		return hits;
+	}
+
+	@Override
+	@Nullable
+	public Object getFacetDistribution() {
+		return facetDistribution;
+	}
+
+	@Override
+	@Nullable
+	public HashMap<String, FacetRating> getFacetStats() {
+		return facetStats;
+	}
+
+	@Override
+	public int getProcessingTimeMs() {
+		return processingTimeMs;
+	}
+
+	@Override
+	public String getQuery() {
+		return query;
+	}
+
+	boolean hasTotalHits() {
+		return totalHits != null;
+	}
+
+	int getTotalHits() {
+		return totalHits != null ? totalHits : hits.size();
+	}
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchTemplate.java
@@ -15,8 +15,8 @@
  */
 package io.vanslog.spring.data.meilisearch.client.msc;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -25,6 +25,9 @@ import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meilisearch.sdk.FacetSearchRequest;
 import com.meilisearch.sdk.MultiSearchFederation;
 import com.meilisearch.sdk.MultiSearchRequest;
@@ -55,6 +58,7 @@ import io.vanslog.spring.data.meilisearch.core.MeilisearchOperations;
 import io.vanslog.spring.data.meilisearch.core.SearchHits;
 import io.vanslog.spring.data.meilisearch.core.convert.MappingMeilisearchConverter;
 import io.vanslog.spring.data.meilisearch.core.convert.MeilisearchConverter;
+import io.vanslog.spring.data.meilisearch.core.document.MeilisearchDocument;
 import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentEntity;
 import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentProperty;
 import io.vanslog.spring.data.meilisearch.core.mapping.SimpleMeilisearchMappingContext;
@@ -73,22 +77,36 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 
 	private final MeilisearchClient meilisearchClient;
 	private final MeilisearchConverter meilisearchConverter;
+	private final ObjectMapper objectMapper;
 	private final RequestConverter requestConverter;
 	private final ResponseConverter responseConverter;
 	private final InstanceResponseConverter instanceResponseConverter;
 	private final MeilisearchInstanceOperations instanceOperations;
 
 	public MeilisearchTemplate(MeilisearchClient meilisearchClient) {
-		this(meilisearchClient, null);
+		this(meilisearchClient, null, new ObjectMapper());
 	}
 
 	public MeilisearchTemplate(MeilisearchClient meilisearchClient, @Nullable MeilisearchConverter meilisearchConverter) {
+		this(meilisearchClient, meilisearchConverter, new ObjectMapper());
+	}
+
+	public MeilisearchTemplate(MeilisearchClient meilisearchClient, ObjectMapper objectMapper) {
+		this(meilisearchClient, null, objectMapper);
+	}
+
+	public MeilisearchTemplate(MeilisearchClient meilisearchClient, @Nullable MeilisearchConverter meilisearchConverter,
+			ObjectMapper objectMapper) {
+
+		Assert.notNull(meilisearchClient, "MeilisearchClient must not be null");
+		Assert.notNull(objectMapper, "ObjectMapper must not be null");
 
 		this.meilisearchClient = meilisearchClient;
 		this.meilisearchConverter = meilisearchConverter != null ? meilisearchConverter
 				: new MappingMeilisearchConverter(new SimpleMeilisearchMappingContext());
+		this.objectMapper = objectMapper;
 		this.requestConverter = new RequestConverter();
-		this.responseConverter = new ResponseConverter();
+		this.responseConverter = new ResponseConverter(this.meilisearchConverter, objectMapper);
 		this.instanceResponseConverter = new InstanceResponseConverter(meilisearchClient.getJsonHandler());
 		this.instanceOperations = new MeilisearchInstanceTemplate(this::execute, instanceResponseConverter);
 	}
@@ -128,7 +146,8 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 		String primaryKey = Objects.requireNonNull(idProperty.getField()).getName();
 
 		TaskInfo taskInfo = execute(client -> {
-			String document = meilisearchClient.getJsonHandler().encode(entities);
+			List<MeilisearchDocument> documents = entities.stream().map(this::toDocument).toList();
+			String document = writeJson(documents);
 			return client.index(indexUid).addDocuments(document, primaryKey);
 		});
 
@@ -143,7 +162,8 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 	public <T> T get(String documentId, Class<T> clazz) {
 		String indexUid = getIndexUidFor(clazz);
 		try {
-			return execute(client -> client.index(indexUid).getDocument(documentId, clazz));
+			String document = execute(client -> client.index(indexUid).getRawDocument(documentId));
+			return readDocument(document, clazz);
 		} catch (DocumentAccessException e) {
 			return null;
 		}
@@ -161,8 +181,8 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 		query.setOffset(offset);
 		query.setLimit(limit);
 
-		T[] results = execute(client -> client.index(indexUid).getDocuments(query, clazz).getResults());
-		return Arrays.asList(results);
+		String results = execute(client -> client.index(indexUid).getRawDocuments(query));
+		return readDocuments(results, clazz);
 	}
 
 	@Override
@@ -189,8 +209,7 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 		query.setOffset(0);
 		query.setLimit(0);
 
-		return execute(client -> client.index(indexUid) //
-				.getDocuments(query, clazz).getTotal()).longValue();
+		return readTotal(execute(client -> client.index(indexUid).getRawDocuments(query)));
 	}
 
 	@Override
@@ -232,7 +251,7 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 	public <T, Q extends BaseQuery> SearchHits<T> search(Q query, Class<T> clazz) {
 		String indexUid = getIndexUidFor(clazz);
 		SearchRequest request = requestConverter.searchRequest(query);
-		Searchable result = execute(client -> client.index(indexUid).search(request));
+		Searchable result = readSearchResult(execute(client -> client.index(indexUid).rawSearch(request)));
 		return responseConverter.mapHits(result, clazz);
 	}
 
@@ -257,7 +276,7 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 	public SearchHits<FacetHit> facetSearch(FacetQuery query, Class<?> clazz) {
 		String indexUid = getIndexUidFor(clazz);
 		FacetSearchRequest request = requestConverter.searchRequest(query);
-		FacetSearchable result = execute(client -> client.index(indexUid).facetSearch(request));
+		FacetSearchable result = readFacetSearchResult(execute(client -> client.index(indexUid).rawFacetSearch(request)));
 		return responseConverter.mapHits(result, FacetHit.class);
 	}
 
@@ -296,7 +315,8 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 		try {
 			return callback.doWithClient(meilisearchClient);
 		} catch (MeilisearchException e) {
-			if (e instanceof MeilisearchApiException ex) {
+			if (e instanceof MeilisearchApiException) {
+				MeilisearchApiException ex = (MeilisearchApiException) e;
 				handleApiException(ex);
 			}
 			throw new UncategorizedMeilisearchException(e.getMessage(), e.getCause());
@@ -347,6 +367,78 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 			return getMeilisearchConverter().convertId(id);
 		} catch (Exception e) {
 			throw new UncategorizedMeilisearchException("Failed to get id.", e);
+		}
+	}
+
+	private MeilisearchDocument toDocument(Object entity) {
+
+		MeilisearchDocument document = MeilisearchDocument.create();
+		meilisearchConverter.write(entity, document);
+		return document;
+	}
+
+	private String writeJson(List<MeilisearchDocument> documents) {
+
+		try {
+			return objectMapper.writeValueAsString(documents);
+		} catch (JsonProcessingException e) {
+			throw new UncategorizedMeilisearchException("Failed to write Meilisearch documents.", e);
+		}
+	}
+
+	private <T> T readDocument(String source, Class<T> clazz) {
+
+		try {
+			MeilisearchDocument document = objectMapper.readValue(source, MeilisearchDocument.class);
+			return meilisearchConverter.read(clazz, document);
+		} catch (IOException e) {
+			throw new UncategorizedMeilisearchException("Failed to read Meilisearch document.", e);
+		}
+	}
+
+	private <T> List<T> readDocuments(String source, Class<T> clazz) {
+
+		try {
+			JsonNode results = objectMapper.readTree(source).get("results");
+			if (results == null || !results.isArray()) {
+				throw new UncategorizedMeilisearchException("Failed to read Meilisearch documents results.");
+			}
+			List<MeilisearchDocument> documents = objectMapper.readerForListOf(MeilisearchDocument.class)
+					.readValue(results);
+			return documents.stream().map(document -> meilisearchConverter.read(clazz, document)).toList();
+		} catch (IOException e) {
+			throw new UncategorizedMeilisearchException("Failed to read Meilisearch documents.", e);
+		}
+	}
+
+	private long readTotal(String source) {
+
+		try {
+			JsonNode total = objectMapper.readTree(source).get("total");
+			if (total == null || !total.canConvertToLong()) {
+				throw new UncategorizedMeilisearchException("Failed to read Meilisearch documents total.");
+			}
+			return total.asLong();
+		} catch (IOException e) {
+			throw new UncategorizedMeilisearchException("Failed to read Meilisearch documents total.", e);
+		}
+	}
+
+	private Searchable readSearchResult(String source) {
+
+		try {
+			return MeilisearchSearchResult.from(objectMapper.readTree(source), objectMapper);
+		} catch (IOException e) {
+			throw new UncategorizedMeilisearchException("Failed to read Meilisearch search result.", e);
+		}
+	}
+
+	private FacetSearchable readFacetSearchResult(String source) {
+
+		try {
+			return MeilisearchFacetSearchResult.from(objectMapper.readTree(source), objectMapper);
+		} catch (IOException e) {
+			throw new UncategorizedMeilisearchException("Failed to read Meilisearch facet search result.", e);
 		}
 	}
 

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchTemplate.java
@@ -48,7 +48,6 @@ import com.meilisearch.sdk.model.TaskStatus;
 import io.vanslog.spring.data.meilisearch.DocumentAccessException;
 import io.vanslog.spring.data.meilisearch.TaskStatusException;
 import io.vanslog.spring.data.meilisearch.UncategorizedMeilisearchException;
-import io.vanslog.spring.data.meilisearch.annotations.Document;
 import io.vanslog.spring.data.meilisearch.client.MeilisearchClient;
 import io.vanslog.spring.data.meilisearch.core.FacetHit;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchCallback;
@@ -58,7 +57,7 @@ import io.vanslog.spring.data.meilisearch.core.MeilisearchOperations;
 import io.vanslog.spring.data.meilisearch.core.SearchHits;
 import io.vanslog.spring.data.meilisearch.core.convert.MappingMeilisearchConverter;
 import io.vanslog.spring.data.meilisearch.core.convert.MeilisearchConverter;
-import io.vanslog.spring.data.meilisearch.core.document.MeilisearchDocument;
+import io.vanslog.spring.data.meilisearch.core.document.Document;
 import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentEntity;
 import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentProperty;
 import io.vanslog.spring.data.meilisearch.core.mapping.SimpleMeilisearchMappingContext;
@@ -146,7 +145,7 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 		String primaryKey = Objects.requireNonNull(idProperty.getField()).getName();
 
 		TaskInfo taskInfo = execute(client -> {
-			List<MeilisearchDocument> documents = entities.stream().map(this::toDocument).toList();
+			List<Document> documents = entities.stream().map(this::toDocument).toList();
 			String document = writeJson(documents);
 			return client.index(indexUid).addDocuments(document, primaryKey);
 		});
@@ -370,14 +369,14 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 		}
 	}
 
-	private MeilisearchDocument toDocument(Object entity) {
+	private Document toDocument(Object entity) {
 
-		MeilisearchDocument document = MeilisearchDocument.create();
+		Document document = Document.create();
 		meilisearchConverter.write(entity, document);
 		return document;
 	}
 
-	private String writeJson(List<MeilisearchDocument> documents) {
+	private String writeJson(List<Document> documents) {
 
 		try {
 			return objectMapper.writeValueAsString(documents);
@@ -389,7 +388,7 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 	private <T> T readDocument(String source, Class<T> clazz) {
 
 		try {
-			MeilisearchDocument document = objectMapper.readValue(source, MeilisearchDocument.class);
+			Document document = objectMapper.readValue(source, Document.class);
 			return meilisearchConverter.read(clazz, document);
 		} catch (IOException e) {
 			throw new UncategorizedMeilisearchException("Failed to read Meilisearch document.", e);
@@ -403,7 +402,7 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 			if (results == null || !results.isArray()) {
 				throw new UncategorizedMeilisearchException("Failed to read Meilisearch documents results.");
 			}
-			List<MeilisearchDocument> documents = objectMapper.readerForListOf(MeilisearchDocument.class)
+			List<Document> documents = objectMapper.readerForListOf(Document.class)
 					.readValue(results);
 			return documents.stream().map(document -> meilisearchConverter.read(clazz, document)).toList();
 		} catch (IOException e) {
@@ -448,7 +447,8 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 	}
 
 	private MeilisearchPersistentEntity<?> getPersistentEntityFor(Class<?> clazz) {
-		Document document = clazz.getAnnotation(Document.class);
+		io.vanslog.spring.data.meilisearch.annotations.Document document = clazz
+				.getAnnotation(io.vanslog.spring.data.meilisearch.annotations.Document.class);
 		Assert.notNull(document, "Given class must be annotated with @Document(indexUid = \"foo\")!");
 		Assert.hasText(document.indexUid(), "Given class must be annotated with @Document(indexUid = \"foo\")!");
 

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchTemplate.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/MeilisearchTemplate.java
@@ -314,8 +314,7 @@ public class MeilisearchTemplate implements MeilisearchOperations {
 		try {
 			return callback.doWithClient(meilisearchClient);
 		} catch (MeilisearchException e) {
-			if (e instanceof MeilisearchApiException) {
-				MeilisearchApiException ex = (MeilisearchApiException) e;
+			if (e instanceof MeilisearchApiException ex) {
 				handleApiException(ex);
 			}
 			throw new UncategorizedMeilisearchException(e.getMessage(), e.getCause());

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverter.java
@@ -15,15 +15,24 @@
  */
 package io.vanslog.spring.data.meilisearch.client.msc;
 
+import io.vanslog.spring.data.meilisearch.core.FacetHit;
 import io.vanslog.spring.data.meilisearch.core.SearchHit;
 import io.vanslog.spring.data.meilisearch.core.SearchHits;
 import io.vanslog.spring.data.meilisearch.core.SearchHitsImpl;
 import io.vanslog.spring.data.meilisearch.core.TotalHitsRelation;
+import io.vanslog.spring.data.meilisearch.core.convert.MappingMeilisearchConverter;
+import io.vanslog.spring.data.meilisearch.core.convert.MeilisearchConverter;
+import io.vanslog.spring.data.meilisearch.core.document.MeilisearchDocument;
 import io.vanslog.spring.data.meilisearch.core.federation.FederationResponse;
+import io.vanslog.spring.data.meilisearch.core.mapping.SimpleMeilisearchMappingContext;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+
+import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meilisearch.sdk.model.FacetSearchable;
@@ -38,31 +47,49 @@ import com.meilisearch.sdk.model.SimilarDocumentsResults;
  */
 public class ResponseConverter {
 
+	private final MeilisearchConverter meilisearchConverter;
 	private final ObjectMapper objectMapper;
 
 	public ResponseConverter() {
-		this.objectMapper = new ObjectMapper();
+		this(new MappingMeilisearchConverter(new SimpleMeilisearchMappingContext()), new ObjectMapper());
 	}
 
-	@SuppressWarnings("unchecked")
-	public <T> List<T> mapHitList(Searchable searchable, Class<?> clazz) {
-		return (List<T>) searchable.getHits().stream() //
-				.map(hit -> objectMapper.convertValue(hit, clazz)) //
-				.map(content -> new SearchHit<>(content, searchable)) //
+	public ResponseConverter(MeilisearchConverter meilisearchConverter) {
+		this(meilisearchConverter, new ObjectMapper());
+	}
+
+	public ResponseConverter(MeilisearchConverter meilisearchConverter, ObjectMapper objectMapper) {
+
+		Assert.notNull(meilisearchConverter, "MeilisearchConverter must not be null");
+		Assert.notNull(objectMapper, "ObjectMapper must not be null");
+
+		this.meilisearchConverter = meilisearchConverter;
+		this.objectMapper = objectMapper;
+	}
+
+	public <T> List<SearchHit<T>> mapHitList(Searchable searchable, Class<T> clazz) {
+		return searchable.getHits().stream() //
+				.map(hit -> new SearchHit<>(readHit(hit, clazz), searchable)) //
 				.toList();
 	}
 
-	@SuppressWarnings("unchecked")
-	public <T> List<T> mapHitList(FacetSearchable searchable, Class<?> clazz) {
-		return (List<T>) searchable.getFacetHits().stream() //
-				.map(hit -> objectMapper.convertValue(hit, clazz)) //
-				.map(content -> new SearchHit<>(content, searchable)) //
+	public <T> List<SearchHit<T>> mapHitList(FacetSearchable searchable, Class<T> clazz) {
+		return searchable.getFacetHits().stream() //
+				.map(hit -> new SearchHit<>(readHit(hit, clazz), searchable)) //
 				.toList();
 	}
 
 	public <T> SearchHits<T> mapHits(Searchable searchable, Class<T> clazz) {
 		List<SearchHit<T>> searchHits = this.mapHitList(searchable, clazz);
 		Duration executionDuration = Duration.ofMillis(searchable.getProcessingTimeMs());
+		if (searchable instanceof MeilisearchSearchResult) {
+			MeilisearchSearchResult result = (MeilisearchSearchResult) searchable;
+			if (result.hasTotalHits()) {
+				return new SearchHitsImpl<>(executionDuration, searchHits, result.getTotalHits(),
+						TotalHitsRelation.EQUAL_TO);
+			}
+		}
+
 		if (searchable instanceof SearchResultPaginated) {
 			SearchResultPaginated result = (SearchResultPaginated) searchable;
 			return new SearchHitsImpl<>(executionDuration, searchHits, result.getTotalHits(),
@@ -80,9 +107,9 @@ public class ResponseConverter {
 	public <T> SearchHits<T> mapResult(MultiSearchResult result, Class<T> clazz) {
 		List<? extends SearchHit<T>> searchHits = result.getHits().stream() //
 				.map(hit -> {
-					FederationResponse federation = objectMapper.convertValue(hit.get("_federation"), FederationResponse.class);
-					hit.remove("_federation");
-					return new SearchHit<>(objectMapper.convertValue(hit, clazz), result, federation);
+					Map<String, Object> source = new LinkedHashMap<>(hit);
+					FederationResponse federation = objectMapper.convertValue(source.remove("_federation"), FederationResponse.class);
+					return new SearchHit<>(readHit(source, clazz), result, federation);
 				}).toList();
 
 		Duration executionDuration = Duration.ofMillis(result.getProcessingTimeMs());
@@ -91,8 +118,7 @@ public class ResponseConverter {
 
 	public <T> SearchHits<T> mapResult(SimilarDocumentsResults result, Class<T> clazz) {
 		List<SearchHit<T>> searchHits = result.getHits().stream() //
-				.map(hit -> objectMapper.convertValue(hit, clazz)) //
-				.map(content -> new SearchHit<>(content, result)) //
+				.map(hit -> new SearchHit<>(readHit(hit, clazz), result)) //
 				.toList();
 
 		Duration executionDuration = Duration.ofMillis(result.getProcessingTimeMs());
@@ -103,8 +129,7 @@ public class ResponseConverter {
 		MultiSearchResult[] multiSearchResults = results.getResults();
 		List<SearchHit<T>> searchHits = Arrays.stream(multiSearchResults) //
 				.flatMap(result -> result.getHits().stream() //
-						.map(hit -> objectMapper.convertValue(hit, clazz)) //
-						.map(content -> new SearchHit<>(content, result)))
+						.map(hit -> new SearchHit<>(readHit(hit, clazz), result)))
 				.toList();
 
 		int maxProcessingTime = Arrays.stream(multiSearchResults) //
@@ -112,5 +137,21 @@ public class ResponseConverter {
 		Duration executionDuration = Duration.ofMillis(maxProcessingTime);
 
 		return new SearchHitsImpl<>(executionDuration, searchHits);
+	}
+
+	private <T> T readHit(Map<String, Object> hit, Class<T> clazz) {
+
+		if (FacetHit.class.equals(clazz)) {
+			return objectMapper.convertValue(hit, clazz);
+		}
+
+		return meilisearchConverter.read(clazz, toDocument(hit));
+	}
+
+	private static MeilisearchDocument toDocument(Map<String, Object> hit) {
+
+		MeilisearchDocument document = MeilisearchDocument.create();
+		document.putAll(hit);
+		return document;
 	}
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverter.java
@@ -82,16 +82,14 @@ public class ResponseConverter {
 	public <T> SearchHits<T> mapHits(Searchable searchable, Class<T> clazz) {
 		List<SearchHit<T>> searchHits = this.mapHitList(searchable, clazz);
 		Duration executionDuration = Duration.ofMillis(searchable.getProcessingTimeMs());
-		if (searchable instanceof MeilisearchSearchResult) {
-			MeilisearchSearchResult result = (MeilisearchSearchResult) searchable;
+		if (searchable instanceof MeilisearchSearchResult result) {
 			if (result.hasTotalHits()) {
 				return new SearchHitsImpl<>(executionDuration, searchHits, result.getTotalHits(),
 						TotalHitsRelation.EQUAL_TO);
 			}
 		}
 
-		if (searchable instanceof SearchResultPaginated) {
-			SearchResultPaginated result = (SearchResultPaginated) searchable;
+		if (searchable instanceof SearchResultPaginated result) {
 			return new SearchHitsImpl<>(executionDuration, searchHits, result.getTotalHits(),
 					TotalHitsRelation.EQUAL_TO);
 		}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverter.java
@@ -22,7 +22,7 @@ import io.vanslog.spring.data.meilisearch.core.SearchHitsImpl;
 import io.vanslog.spring.data.meilisearch.core.TotalHitsRelation;
 import io.vanslog.spring.data.meilisearch.core.convert.MappingMeilisearchConverter;
 import io.vanslog.spring.data.meilisearch.core.convert.MeilisearchConverter;
-import io.vanslog.spring.data.meilisearch.core.document.MeilisearchDocument;
+import io.vanslog.spring.data.meilisearch.core.document.Document;
 import io.vanslog.spring.data.meilisearch.core.federation.FederationResponse;
 import io.vanslog.spring.data.meilisearch.core.mapping.SimpleMeilisearchMappingContext;
 
@@ -148,9 +148,9 @@ public class ResponseConverter {
 		return meilisearchConverter.read(clazz, toDocument(hit));
 	}
 
-	private static MeilisearchDocument toDocument(Map<String, Object> hit) {
+	private static Document toDocument(Map<String, Object> hit) {
 
-		MeilisearchDocument document = MeilisearchDocument.create();
+		Document document = Document.create();
 		document.putAll(hit);
 		return document;
 	}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfiguration.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfiguration.java
@@ -21,8 +21,10 @@ import io.vanslog.spring.data.meilisearch.client.msc.MeilisearchTemplate;
 import io.vanslog.spring.data.meilisearch.core.MeilisearchOperations;
 import io.vanslog.spring.data.meilisearch.core.convert.MeilisearchConverter;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meilisearch.sdk.json.GsonJsonHandler;
 import com.meilisearch.sdk.json.JsonHandler;
 
@@ -59,12 +61,13 @@ public abstract class MeilisearchConfiguration extends MeilisearchConfigurationS
 	 *
 	 * @param meilisearchClient the Meilisearch client
 	 * @param meilisearchConverter the Meilisearch converter
+	 * @param objectMapper the object mapper for JSON document payloads
 	 * @return the created {@link io.vanslog.spring.data.meilisearch.core.MeilisearchOperations} bean.
 	 */
 	@Bean(name = { "meilisearchOperations", "meilisearchTemplate" })
 	public MeilisearchOperations meilisearchOperations(MeilisearchClient meilisearchClient,
-			MeilisearchConverter meilisearchConverter) {
-		return new MeilisearchTemplate(meilisearchClient, meilisearchConverter);
+			MeilisearchConverter meilisearchConverter, @Qualifier("meilisearchObjectMapper") ObjectMapper objectMapper) {
+		return new MeilisearchTemplate(meilisearchClient, meilisearchConverter, objectMapper);
 	}
 
 	/**

--- a/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfigurationSupport.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfigurationSupport.java
@@ -26,6 +26,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * Support class for{@link io.vanslog.spring.data.meilisearch.config.MeilisearchConfiguration}.
  *
@@ -68,5 +70,15 @@ public class MeilisearchConfigurationSupport {
 	@Bean
 	public MeilisearchCustomConversions meilisearchCustomConversions() {
 		return new MeilisearchCustomConversions(Collections.emptyList());
+	}
+
+	/**
+	 * Register the {@link ObjectMapper} used for JSON document payloads.
+	 *
+	 * @return never {@literal null}.
+	 */
+	@Bean(name = "meilisearchObjectMapper")
+	public ObjectMapper meilisearchObjectMapper() {
+		return new ObjectMapper();
 	}
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/FacetHit.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/FacetHit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/FacetHit.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/FacetHit.java
@@ -1,4 +1,24 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vanslog.spring.data.meilisearch.core;
 
+/**
+ * Facet search hit response.
+ *
+ * @author Junghoon Ban
+ */
 public record FacetHit(String value, int count) {
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverter.java
@@ -15,10 +15,16 @@
  */
 package io.vanslog.spring.data.meilisearch.core.convert;
 
+import io.vanslog.spring.data.meilisearch.core.document.MeilisearchDocument;
 import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentEntity;
 import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentProperty;
 
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.InitializingBean;
@@ -28,9 +34,16 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.data.convert.CustomConversions;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.PropertyHandler;
+import org.springframework.data.mapping.context.AbstractMappingContext;
 import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.mapping.model.EntityInstantiators;
+import org.springframework.data.mapping.model.PersistentEntityParameterValueProvider;
+import org.springframework.data.mapping.model.PropertyValueProvider;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 
 /**
  * {@link io.vanslog.spring.data.meilisearch.core.convert.MeilisearchConverter} Implementation based on
@@ -42,6 +55,7 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 
 	private final MappingContext<? extends MeilisearchPersistentEntity<?>, MeilisearchPersistentProperty> mappingContext;
 	private final GenericConversionService conversionService;
+	private final EntityInstantiators instantiators = new EntityInstantiators();
 	private CustomConversions conversions = new MeilisearchCustomConversions(Collections.emptyList());
 
 	@SuppressWarnings("unused, FieldCanBeLocal")
@@ -75,15 +89,236 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 		return this.conversionService;
 	}
 
+	@Override
+	public <R> R read(Class<R> type, MeilisearchDocument source) {
+
+		Assert.notNull(type, "Type must not be null");
+		Assert.notNull(source, "Source document must not be null");
+
+		if (conversions.hasCustomReadTarget(MeilisearchDocument.class, type)) {
+			R converted = conversionService.convert(source, type);
+			if (converted != null) {
+				return converted;
+			}
+		}
+
+		MeilisearchPersistentEntity<R> entity = getPersistentEntity(type);
+		R instance = instantiators.getInstantiatorFor(entity).createInstance(entity,
+				new PersistentEntityParameterValueProvider<>(entity, propertyValueProvider(source), null));
+		PersistentPropertyAccessor<R> accessor = entity.getPropertyAccessor(instance);
+
+		entity.doWithProperties((PropertyHandler<MeilisearchPersistentProperty>) property -> {
+			if (entity.isCreatorArgument(property)) {
+				return;
+			}
+			String fieldName = property.getFieldName();
+			if (!source.containsKey(fieldName)) {
+				return;
+			}
+			Class<?> componentType = property.isCollectionLike() ? property.getComponentType() : property.getActualType();
+			accessor.setProperty(property, readValue(source.get(fieldName), property.getType(), componentType));
+		});
+
+		return instance;
+	}
+
+	@SuppressWarnings("unchecked")
+	private <R> MeilisearchPersistentEntity<R> getPersistentEntity(Class<R> type) {
+		return (MeilisearchPersistentEntity<R>) mappingContext.getRequiredPersistentEntity(type);
+	}
+
+	private PropertyValueProvider<MeilisearchPersistentProperty> propertyValueProvider(MeilisearchDocument source) {
+
+		return new PropertyValueProvider<MeilisearchPersistentProperty>() {
+			@Override
+			@SuppressWarnings("unchecked")
+			public <T> T getPropertyValue(MeilisearchPersistentProperty property) {
+				String fieldName = property.getFieldName();
+				Class<?> componentType = property.isCollectionLike() ? property.getComponentType()
+						: property.getActualType();
+				return (T) readValue(source.get(fieldName), property.getType(), componentType);
+			}
+		};
+	}
+
+	@Override
+	public void write(Object source, MeilisearchDocument sink) {
+
+		Assert.notNull(source, "Source object must not be null");
+		Assert.notNull(sink, "Sink document must not be null");
+
+		MeilisearchPersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(source.getClass());
+		PersistentPropertyAccessor<?> accessor = entity.getPropertyAccessor(source);
+
+		entity.doWithProperties((PropertyHandler<MeilisearchPersistentProperty>) property -> {
+			Object value = accessor.getProperty(property);
+			if (value != null) {
+				sink.put(property.getFieldName(), writeValue(value));
+			}
+		});
+	}
+
+	@Nullable
+	private Object writeValue(@Nullable Object value) {
+
+		if (value == null) {
+			return null;
+		}
+
+		if (conversions.hasCustomWriteTarget(value.getClass(), MeilisearchDocument.class)) {
+			Object converted = conversionService.convert(value, MeilisearchDocument.class);
+			if (converted != null) {
+				return converted;
+			}
+		}
+
+		if (isSimpleType(value.getClass())) {
+			return value;
+		}
+
+		if (value instanceof Collection<?>) {
+			Collection<?> collection = (Collection<?>) value;
+			Collection<Object> converted = new ArrayList<>(collection.size());
+			for (Object element : collection) {
+				converted.add(writeValue(element));
+			}
+			return converted;
+		}
+
+		if (value.getClass().isArray()) {
+			int length = Array.getLength(value);
+			Collection<Object> converted = new ArrayList<>(length);
+			for (int i = 0; i < length; i++) {
+				converted.add(writeValue(Array.get(value, i)));
+			}
+			return converted;
+		}
+
+		if (value instanceof Map<?, ?>) {
+			Map<?, ?> map = (Map<?, ?>) value;
+			Map<String, Object> converted = new LinkedHashMap<>(map.size());
+			map.forEach((key, mapValue) -> converted.put(String.valueOf(key), writeValue(mapValue)));
+			return converted;
+		}
+
+		MeilisearchDocument document = MeilisearchDocument.create();
+		write(value, document);
+		return document;
+	}
+
+	@Nullable
+	private Object readValue(@Nullable Object value, Class<?> targetType, Class<?> componentType) {
+
+		if (value == null) {
+			return null;
+		}
+
+		if (conversions.hasCustomReadTarget(value.getClass(), targetType)) {
+			Object converted = conversionService.convert(value, targetType);
+			if (converted != null) {
+				return converted;
+			}
+		}
+
+		if (Collection.class.isAssignableFrom(targetType) && value instanceof Collection<?>) {
+			Collection<?> collection = (Collection<?>) value;
+			Collection<Object> converted = new ArrayList<>(collection.size());
+			Class<?> elementType = componentType != null ? componentType : Object.class;
+			for (Object element : collection) {
+				converted.add(readCollectionElement(element, elementType));
+			}
+			return converted;
+		}
+
+		if (ClassUtils.isAssignableValue(targetType, value)) {
+			return value;
+		}
+
+		if (conversionService.canConvert(value.getClass(), targetType)) {
+			Object converted = conversionService.convert(value, targetType);
+			if (converted != null) {
+				return converted;
+			}
+		}
+
+		if (value instanceof MeilisearchDocument) {
+			MeilisearchDocument document = (MeilisearchDocument) value;
+			return read(targetType, document);
+		}
+
+		if (value instanceof Map<?, ?>) {
+			Map<?, ?> map = (Map<?, ?>) value;
+			return read(targetType, toDocument(map));
+		}
+
+		return value;
+	}
+
+	@Nullable
+	private Object readCollectionElement(@Nullable Object element, Class<?> componentType) {
+
+		if (element == null || ClassUtils.isAssignableValue(componentType, element)) {
+			return element;
+		}
+
+		if (conversions.hasCustomReadTarget(element.getClass(), componentType)) {
+			Object converted = conversionService.convert(element, componentType);
+			if (converted != null) {
+				return converted;
+			}
+		}
+
+		if (element instanceof MeilisearchDocument) {
+			MeilisearchDocument document = (MeilisearchDocument) element;
+			return read(componentType, document);
+		}
+
+		if (element instanceof Map<?, ?>) {
+			Map<?, ?> map = (Map<?, ?>) element;
+			return read(componentType, toDocument(map));
+		}
+
+		return element;
+	}
+
+	private boolean isSimpleType(Class<?> type) {
+		return conversions.getSimpleTypeHolder().isSimpleType(type);
+	}
+
+	private void updateMappingContextSimpleTypeHolder() {
+
+		if (mappingContext instanceof AbstractMappingContext<?, ?>) {
+			setSimpleTypeHolder(mappingContext, conversions);
+		}
+	}
+
+	@SuppressWarnings("rawtypes")
+	private static void setSimpleTypeHolder(
+			MappingContext<? extends MeilisearchPersistentEntity<?>, MeilisearchPersistentProperty> mappingContext,
+			CustomConversions conversions) {
+
+		AbstractMappingContext abstractMappingContext = (AbstractMappingContext) mappingContext;
+		abstractMappingContext.setSimpleTypeHolder(conversions.getSimpleTypeHolder());
+	}
+
+	private static MeilisearchDocument toDocument(Map<?, ?> source) {
+
+		MeilisearchDocument document = MeilisearchDocument.create();
+		source.forEach((key, value) -> document.put(String.valueOf(key), value));
+		return document;
+	}
+
 	public void setConversions(CustomConversions conversions) {
 
 		Assert.notNull(conversions, "CustomConversions must not be null");
 
 		this.conversions = conversions;
+		updateMappingContextSimpleTypeHolder();
 	}
 
 	@Override
 	public void afterPropertiesSet() {
+		updateMappingContextSimpleTypeHolder();
 		conversions.registerConvertersIn(conversionService);
 	}
 }

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverter.java
@@ -207,7 +207,7 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 	}
 
 	@Nullable
-	private Object readValue(@Nullable Object value, Class<?> targetType, Class<?> componentType) {
+	private Object readValue(@Nullable Object value, Class<?> targetType, @Nullable Class<?> componentType) {
 
 		if (value == null) {
 			return null;

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverter.java
@@ -15,7 +15,7 @@
  */
 package io.vanslog.spring.data.meilisearch.core.convert;
 
-import io.vanslog.spring.data.meilisearch.core.document.MeilisearchDocument;
+import io.vanslog.spring.data.meilisearch.core.document.Document;
 import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentEntity;
 import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentProperty;
 
@@ -94,12 +94,12 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 	}
 
 	@Override
-	public <R> R read(Class<R> type, MeilisearchDocument source) {
+	public <R> R read(Class<R> type, Document source) {
 
 		Assert.notNull(type, "Type must not be null");
 		Assert.notNull(source, "Source document must not be null");
 
-		if (conversions.hasCustomReadTarget(MeilisearchDocument.class, type)) {
+		if (conversions.hasCustomReadTarget(Document.class, type)) {
 			R converted = conversionService.convert(source, type);
 			if (converted != null) {
 				return converted;
@@ -131,7 +131,7 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 		return (MeilisearchPersistentEntity<R>) mappingContext.getRequiredPersistentEntity(type);
 	}
 
-	private PropertyValueProvider<MeilisearchPersistentProperty> propertyValueProvider(MeilisearchDocument source) {
+	private PropertyValueProvider<MeilisearchPersistentProperty> propertyValueProvider(Document source) {
 
 		return new PropertyValueProvider<MeilisearchPersistentProperty>() {
 			@Override
@@ -146,7 +146,7 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 	}
 
 	@Override
-	public void write(Object source, MeilisearchDocument sink) {
+	public void write(Object source, Document sink) {
 
 		Assert.notNull(source, "Source object must not be null");
 		Assert.notNull(sink, "Sink document must not be null");
@@ -169,8 +169,8 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 			return null;
 		}
 
-		if (conversions.hasCustomWriteTarget(value.getClass(), MeilisearchDocument.class)) {
-			Object converted = conversionService.convert(value, MeilisearchDocument.class);
+		if (conversions.hasCustomWriteTarget(value.getClass(), Document.class)) {
+			Object converted = conversionService.convert(value, Document.class);
 			if (converted != null) {
 				return converted;
 			}
@@ -205,7 +205,7 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 			return converted;
 		}
 
-		MeilisearchDocument document = MeilisearchDocument.create();
+		Document document = Document.create();
 		write(value, document);
 		return document;
 	}
@@ -245,8 +245,8 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 			}
 		}
 
-		if (value instanceof MeilisearchDocument) {
-			MeilisearchDocument document = (MeilisearchDocument) value;
+		if (value instanceof Document) {
+			Document document = (Document) value;
 			return read(targetType, document);
 		}
 
@@ -272,8 +272,8 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 			}
 		}
 
-		if (element instanceof MeilisearchDocument) {
-			MeilisearchDocument document = (MeilisearchDocument) element;
+		if (element instanceof Document) {
+			Document document = (Document) element;
 			return read(componentType, document);
 		}
 
@@ -314,9 +314,9 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 		abstractMappingContext.setSimpleTypeHolder(conversions.getSimpleTypeHolder());
 	}
 
-	private static MeilisearchDocument toDocument(Map<?, ?> source) {
+	private static Document toDocument(Map<?, ?> source) {
 
-		MeilisearchDocument document = MeilisearchDocument.create();
+		Document document = Document.create();
 		source.forEach((key, value) -> document.put(String.valueOf(key), value));
 		return document;
 	}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverter.java
@@ -180,8 +180,7 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 			return value;
 		}
 
-		if (value instanceof Collection<?>) {
-			Collection<?> collection = (Collection<?>) value;
+		if (value instanceof Collection<?> collection) {
 			Collection<Object> converted = new ArrayList<>(collection.size());
 			for (Object element : collection) {
 				converted.add(writeValue(element));
@@ -198,8 +197,7 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 			return converted;
 		}
 
-		if (value instanceof Map<?, ?>) {
-			Map<?, ?> map = (Map<?, ?>) value;
+		if (value instanceof Map<?, ?> map) {
 			Map<String, Object> converted = new LinkedHashMap<>(map.size());
 			map.forEach((key, mapValue) -> converted.put(String.valueOf(key), writeValue(mapValue)));
 			return converted;
@@ -224,8 +222,7 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 			}
 		}
 
-		if (Collection.class.isAssignableFrom(targetType) && value instanceof Collection<?>) {
-			Collection<?> collection = (Collection<?>) value;
+		if (Collection.class.isAssignableFrom(targetType) && value instanceof Collection<?> collection) {
 			Class<?> elementType = componentType != null ? componentType : Object.class;
 			Collection<Object> converted = createCollection(targetType, elementType, collection.size());
 			for (Object element : collection) {
@@ -245,13 +242,11 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 			}
 		}
 
-		if (value instanceof Document) {
-			Document document = (Document) value;
+		if (value instanceof Document document) {
 			return read(targetType, document);
 		}
 
-		if (value instanceof Map<?, ?>) {
-			Map<?, ?> map = (Map<?, ?>) value;
+		if (value instanceof Map<?, ?> map) {
 			return read(targetType, toDocument(map));
 		}
 
@@ -272,13 +267,11 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 			}
 		}
 
-		if (element instanceof Document) {
-			Document document = (Document) element;
+		if (element instanceof Document document) {
 			return read(componentType, document);
 		}
 
-		if (element instanceof Map<?, ?>) {
-			Map<?, ?> map = (Map<?, ?>) element;
+		if (element instanceof Map<?, ?> map) {
 			return read(componentType, toDocument(map));
 		}
 
@@ -300,17 +293,14 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 
 	private void updateMappingContextSimpleTypeHolder() {
 
-		if (mappingContext instanceof AbstractMappingContext<?, ?>) {
-			setSimpleTypeHolder(mappingContext, conversions);
+		if (mappingContext instanceof AbstractMappingContext<?, ?> abstractMappingContext) {
+			setSimpleTypeHolder(abstractMappingContext, conversions);
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
-	private static void setSimpleTypeHolder(
-			MappingContext<? extends MeilisearchPersistentEntity<?>, MeilisearchPersistentProperty> mappingContext,
+	private static void setSimpleTypeHolder(AbstractMappingContext<?, ?> abstractMappingContext,
 			CustomConversions conversions) {
 
-		AbstractMappingContext abstractMappingContext = (AbstractMappingContext) mappingContext;
 		abstractMappingContext.setSimpleTypeHolder(conversions.getSimpleTypeHolder());
 	}
 

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverter.java
@@ -20,16 +20,20 @@ import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentEnti
 import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentProperty;
 
 import java.lang.reflect.Array;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Queue;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.CollectionFactory;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
@@ -222,8 +226,8 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 
 		if (Collection.class.isAssignableFrom(targetType) && value instanceof Collection<?>) {
 			Collection<?> collection = (Collection<?>) value;
-			Collection<Object> converted = new ArrayList<>(collection.size());
 			Class<?> elementType = componentType != null ? componentType : Object.class;
+			Collection<Object> converted = createCollection(targetType, elementType, collection.size());
 			for (Object element : collection) {
 				converted.add(readCollectionElement(element, elementType));
 			}
@@ -279,6 +283,15 @@ public class MappingMeilisearchConverter implements MeilisearchConverter, Applic
 		}
 
 		return element;
+	}
+
+	private static Collection<Object> createCollection(Class<?> targetType, Class<?> elementType, int size) {
+
+		if (Queue.class == targetType || Deque.class == targetType) {
+			return new ArrayDeque<>(size);
+		}
+
+		return CollectionFactory.createCollection(targetType, elementType, size);
 	}
 
 	private boolean isSimpleType(Class<?> type) {

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MeilisearchConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MeilisearchConverter.java
@@ -15,10 +15,12 @@
  */
 package io.vanslog.spring.data.meilisearch.core.convert;
 
+import io.vanslog.spring.data.meilisearch.core.document.MeilisearchDocument;
 import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentEntity;
 import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentProperty;
 
 import org.springframework.core.convert.ConversionService;
+import org.springframework.data.convert.EntityConverter;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.util.Assert;
 
@@ -28,7 +30,8 @@ import org.springframework.util.Assert;
  * @author Junghoon Ban
  * @see MappingContext
  */
-public interface MeilisearchConverter {
+public interface MeilisearchConverter
+		extends EntityConverter<MeilisearchPersistentEntity<?>, MeilisearchPersistentProperty, Object, MeilisearchDocument> {
 
 	/**
 	 * Returns the {@link org.springframework.data.mapping.context.MappingContext}. used by the converter.

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MeilisearchConverter.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/convert/MeilisearchConverter.java
@@ -15,7 +15,7 @@
  */
 package io.vanslog.spring.data.meilisearch.core.convert;
 
-import io.vanslog.spring.data.meilisearch.core.document.MeilisearchDocument;
+import io.vanslog.spring.data.meilisearch.core.document.Document;
 import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentEntity;
 import io.vanslog.spring.data.meilisearch.core.mapping.MeilisearchPersistentProperty;
 
@@ -31,7 +31,7 @@ import org.springframework.util.Assert;
  * @see MappingContext
  */
 public interface MeilisearchConverter
-		extends EntityConverter<MeilisearchPersistentEntity<?>, MeilisearchPersistentProperty, Object, MeilisearchDocument> {
+		extends EntityConverter<MeilisearchPersistentEntity<?>, MeilisearchPersistentProperty, Object, Document> {
 
 	/**
 	 * Returns the {@link org.springframework.data.mapping.context.MappingContext}. used by the converter.

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/document/Document.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/document/Document.java
@@ -22,15 +22,15 @@ import java.util.LinkedHashMap;
  *
  * @author Junghoon Ban
  */
-public class MeilisearchDocument extends LinkedHashMap<String, Object> {
+public class Document extends LinkedHashMap<String, Object> {
 
 	private static final long serialVersionUID = 1L;
 
-	public static MeilisearchDocument create() {
-		return new MeilisearchDocument();
+	public static Document create() {
+		return new Document();
 	}
 
-	public MeilisearchDocument append(String key, Object value) {
+	public Document append(String key, Object value) {
 
 		put(key, value);
 		return this;

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/document/MeilisearchDocument.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/document/MeilisearchDocument.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.core.document;
+
+import java.util.LinkedHashMap;
+
+/**
+ * Map-shaped Meilisearch document representation used between entity mapping and JSON serialization.
+ *
+ * @author Junghoon Ban
+ */
+public class MeilisearchDocument extends LinkedHashMap<String, Object> {
+
+	private static final long serialVersionUID = 1L;
+
+	public static MeilisearchDocument create() {
+		return new MeilisearchDocument();
+	}
+
+	public MeilisearchDocument append(String key, Object value) {
+
+		put(key, value);
+		return this;
+	}
+}

--- a/src/main/java/io/vanslog/spring/data/meilisearch/core/document/package-info.java
+++ b/src/main/java/io/vanslog/spring/data/meilisearch/core/document/package-info.java
@@ -1,0 +1,3 @@
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package io.vanslog.spring.data.meilisearch.core.document;

--- a/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverterUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverterUnitTests.java
@@ -20,10 +20,15 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.convert.ReadingConverter;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meilisearch.sdk.model.FacetSearchable;
 import com.meilisearch.sdk.model.MultiSearchResult;
 import com.meilisearch.sdk.model.Results;
@@ -34,6 +39,12 @@ import com.meilisearch.sdk.model.SimilarDocumentsResults;
 import io.vanslog.spring.data.meilisearch.core.SearchHit;
 import io.vanslog.spring.data.meilisearch.core.SearchHits;
 import io.vanslog.spring.data.meilisearch.core.TotalHitsRelation;
+import io.vanslog.spring.data.meilisearch.annotations.Document;
+import io.vanslog.spring.data.meilisearch.core.FacetHit;
+import io.vanslog.spring.data.meilisearch.core.convert.MappingMeilisearchConverter;
+import io.vanslog.spring.data.meilisearch.core.convert.MeilisearchCustomConversions;
+import io.vanslog.spring.data.meilisearch.core.document.MeilisearchDocument;
+import io.vanslog.spring.data.meilisearch.core.mapping.SimpleMeilisearchMappingContext;
 
 /**
  * Unit tests for {@link ResponseConverter}.
@@ -60,6 +71,39 @@ class ResponseConverterUnitTests {
 		assertThat(searchHits.getSearchHits()).hasSize(2);
 		assertThat(searchHits.getTotalHits()).isEqualTo(10);
 		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.EQUAL_TO);
+	}
+
+	@Test
+	void shouldConvertRawPaginatedTotalHitsMetadataToSearchHits() throws Exception {
+		ObjectMapper objectMapper = new ObjectMapper();
+		MeilisearchSearchResult result = MeilisearchSearchResult.from(objectMapper.readTree("{"
+				+ "\"hits\": [{\"id\": \"143\", \"title\": \"Escape Room\"}],"
+				+ "\"processingTimeMs\": 25,"
+				+ "\"query\": \"escape\","
+				+ "\"totalHits\": 10"
+				+ "}"), objectMapper);
+
+		SearchHits<SimilarMovie> searchHits = converter.mapHits(result, SimilarMovie.class);
+
+		assertThat(searchHits.getSearchHits()).hasSize(1);
+		assertThat(searchHits.getTotalHits()).isEqualTo(10);
+		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.EQUAL_TO);
+	}
+
+	@Test
+	void shouldConvertRawFacetStatsToFacetRating() throws Exception {
+		ObjectMapper objectMapper = new ObjectMapper();
+		MeilisearchSearchResult result = MeilisearchSearchResult.from(objectMapper.readTree("{"
+				+ "\"hits\": [{\"id\": \"143\", \"title\": \"Escape Room\"}],"
+				+ "\"processingTimeMs\": 25,"
+				+ "\"query\": \"escape\","
+				+ "\"facetStats\": {\"rating\": {\"min\": 1, \"max\": 5}}"
+				+ "}"), objectMapper);
+
+		SearchHits<SimilarMovie> searchHits = converter.mapHits(result, SimilarMovie.class);
+
+		assertThat(searchHits.getSearchHit(0).getFacetStats().get("rating").getMin()).isEqualTo(1);
+		assertThat(searchHits.getSearchHit(0).getFacetStats().get("rating").getMax()).isEqualTo(5);
 	}
 
 	@Test
@@ -148,10 +192,61 @@ class ResponseConverterUnitTests {
 		assertThat(searchHits.getTotalHitsRelation()).isEqualTo(TotalHitsRelation.OFF);
 	}
 
+	@Test
+	void shouldMapFacetHitsAsResponseDtos() {
+		FacetSearchable result = new FacetSearchable() {
+			@Override
+			public ArrayList<HashMap<String, Object>> getFacetHits() {
+				return new ArrayList<>(List.of(facetHit("Drama", 2)));
+			}
+
+			@Override
+			public int getProcessingTimeMs() {
+				return 25;
+			}
+
+			@Override
+			public String getFacetQuery() {
+				return "Dra";
+			}
+		};
+
+		SearchHits<FacetHit> searchHits = converter.mapHits(result, FacetHit.class);
+
+		assertThat(searchHits.getSearchHit(0).getContent().value()).isEqualTo("Drama");
+		assertThat(searchHits.getSearchHit(0).getContent().count()).isEqualTo(2);
+	}
+
+	@Test
+	void shouldMaterializeSearchHitsThroughMeilisearchConverter() {
+		MappingMeilisearchConverter mappingConverter = new MappingMeilisearchConverter(
+				new SimpleMeilisearchMappingContext());
+		mappingConverter.setConversions(new MeilisearchCustomConversions(List.of(new DocumentToCodeConverter())));
+		mappingConverter.afterPropertiesSet();
+		ResponseConverter converter = new ResponseConverter(mappingConverter, new ObjectMapper());
+		SearchResult result = new SearchResult();
+		HashMap<String, Object> hit = hit("143", "Escape Room");
+		hit.put("code", Map.of("raw", "custom-code"));
+
+		ReflectionTestUtils.setField(result, "hits", new ArrayList<>(List.of(hit)));
+		ReflectionTestUtils.setField(result, "processingTimeMs", 25);
+
+		SearchHits<MovieWithConvertedProperty> searchHits = converter.mapHits(result, MovieWithConvertedProperty.class);
+
+		assertThat(searchHits.getSearchHit(0).getContent().getCode().getValue()).isEqualTo("custom-code");
+	}
+
 	private static HashMap<String, Object> hit(String id, String title) {
 		HashMap<String, Object> hit = new HashMap<>();
 		hit.put("id", id);
 		hit.put("title", title);
+		return hit;
+	}
+
+	private static HashMap<String, Object> facetHit(String value, int count) {
+		HashMap<String, Object> hit = new HashMap<>();
+		hit.put("value", value);
+		hit.put("count", count);
 		return hit;
 	}
 
@@ -174,6 +269,43 @@ class ResponseConverterUnitTests {
 
 		public void setTitle(String title) {
 			this.title = title;
+		}
+	}
+
+	@Document(indexUid = "converted-movies")
+	static class MovieWithConvertedProperty {
+
+		@Id private String id;
+		private Code code;
+
+		public String getId() {
+			return id;
+		}
+
+		public Code getCode() {
+			return code;
+		}
+	}
+
+	static class Code {
+
+		private final String value;
+
+		Code(String value) {
+			this.value = value;
+		}
+
+		String getValue() {
+			return value;
+		}
+	}
+
+	@ReadingConverter
+	static class DocumentToCodeConverter implements Converter<MeilisearchDocument, Code> {
+
+		@Override
+		public Code convert(MeilisearchDocument source) {
+			return new Code((String) source.get("raw"));
 		}
 	}
 }

--- a/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverterUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/client/msc/ResponseConverterUnitTests.java
@@ -39,11 +39,10 @@ import com.meilisearch.sdk.model.SimilarDocumentsResults;
 import io.vanslog.spring.data.meilisearch.core.SearchHit;
 import io.vanslog.spring.data.meilisearch.core.SearchHits;
 import io.vanslog.spring.data.meilisearch.core.TotalHitsRelation;
-import io.vanslog.spring.data.meilisearch.annotations.Document;
 import io.vanslog.spring.data.meilisearch.core.FacetHit;
 import io.vanslog.spring.data.meilisearch.core.convert.MappingMeilisearchConverter;
 import io.vanslog.spring.data.meilisearch.core.convert.MeilisearchCustomConversions;
-import io.vanslog.spring.data.meilisearch.core.document.MeilisearchDocument;
+import io.vanslog.spring.data.meilisearch.core.document.Document;
 import io.vanslog.spring.data.meilisearch.core.mapping.SimpleMeilisearchMappingContext;
 
 /**
@@ -272,7 +271,7 @@ class ResponseConverterUnitTests {
 		}
 	}
 
-	@Document(indexUid = "converted-movies")
+	@io.vanslog.spring.data.meilisearch.annotations.Document(indexUid = "converted-movies")
 	static class MovieWithConvertedProperty {
 
 		@Id private String id;
@@ -301,10 +300,10 @@ class ResponseConverterUnitTests {
 	}
 
 	@ReadingConverter
-	static class DocumentToCodeConverter implements Converter<MeilisearchDocument, Code> {
+	static class DocumentToCodeConverter implements Converter<Document, Code> {
 
 		@Override
-		public Code convert(MeilisearchDocument source) {
+		public Code convert(Document source) {
 			return new Code((String) source.get("raw"));
 		}
 	}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfigurationUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchConfigurationUnitTests.java
@@ -27,11 +27,14 @@ import io.vanslog.spring.data.meilisearch.repository.config.EnableMeilisearchRep
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.annotation.Id;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meilisearch.sdk.json.JacksonJsonHandler;
 import com.meilisearch.sdk.json.JsonHandler;
 
@@ -47,6 +50,7 @@ class MeilisearchConfigurationUnitTests {
 	@Autowired private MeilisearchClient meilisearchClient;
 	@Autowired private MeilisearchOperations meilisearchTemplate;
 	@Autowired private io.vanslog.spring.data.meilisearch.client.msc.MeilisearchTemplate clientMeilisearchTemplate;
+	@Autowired @Qualifier("meilisearchObjectMapper") private ObjectMapper objectMapper;
 	@Autowired private ApplySettingsFalseRepository applySettingsFalseRepository;
 
 	@Test
@@ -64,6 +68,12 @@ class MeilisearchConfigurationUnitTests {
 	@Test
 	void shouldCreateMeilisearchTemplate() {
 		assertThat(meilisearchTemplate).isNotNull();
+	}
+
+	@Test
+	void shouldWireSpringManagedObjectMapperIntoMeilisearchTemplate() {
+		assertThat(objectMapper).isNotNull();
+		assertThat(ReflectionTestUtils.getField(clientMeilisearchTemplate, "objectMapper")).isSameAs(objectMapper);
 	}
 
 	@Test

--- a/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchNamespaceHandlerUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/config/MeilisearchNamespaceHandlerUnitTests.java
@@ -31,8 +31,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.annotation.Id;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.vanslog.spring.data.meilisearch.core.convert.MeilisearchConverter;
 
 /**
  * Namespace based configuration test.
@@ -54,6 +59,15 @@ class MeilisearchNamespaceHandlerUnitTests {
 	void shouldCreateMeilisearchTemplate() {
 		assertThat(context.getBean(MeilisearchTemplate.class)).isInstanceOf(MeilisearchTemplate.class);
 		assertThat(context.getBean("meilisearchTemplate", MeilisearchOperations.class)).isNotNull();
+	}
+
+	@Test
+	void shouldWireConfiguredConverterAndObjectMapperIntoMeilisearchTemplate() {
+		MeilisearchTemplate template = context.getBean(MeilisearchTemplate.class);
+
+		assertThat(ReflectionTestUtils.getField(template, "meilisearchConverter"))
+				.isSameAs(context.getBean(MeilisearchConverter.class));
+		assertThat(ReflectionTestUtils.getField(template, "objectMapper")).isSameAs(context.getBean(ObjectMapper.class));
 	}
 
 	@Test

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateIntegrationTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/MeilisearchTemplateIntegrationTests.java
@@ -67,7 +67,7 @@ class MeilisearchTemplateIntegrationTests {
 
 	private static final List<String> LIFECYCLE_INDEX_UIDS = List.of("lifecycle-create-index",
 			"lifecycle-get-list-index", "lifecycle-update-index", "lifecycle-delete-index", "runtime-settings-index",
-			"runtime-settings-reset-index");
+			"runtime-settings-reset-index", "nested-movies");
 
 	@BeforeEach
 	void setUp() throws MeilisearchException {
@@ -527,6 +527,21 @@ class MeilisearchTemplateIntegrationTests {
 		assertThat(meilisearchTemplate.exists(documentId, AnnotatedIdField.class)).isTrue();
 	}
 
+	@Test
+	void shouldRoundTripNestedDocumentsThroughTemplateMapping() {
+
+		NestedMovie nestedMovie = new NestedMovie("nested-1", "Nested Search", new MovieDetails("Director", 2026));
+
+		meilisearchTemplate.save(nestedMovie);
+
+		NestedMovie saved = meilisearchTemplate.get("nested-1", NestedMovie.class);
+		SearchHits<NestedMovie> searchHits = meilisearchTemplate.search(new BasicQuery("Nested"), NestedMovie.class);
+
+		assertThat(saved.getDetails().getDirector()).isEqualTo("Director");
+		assertThat(saved.getDetails().getYear()).isEqualTo(2026);
+		assertThat(searchHits.getSearchHit(0).getContent().getDetails().getDirector()).isEqualTo("Director");
+	}
+
 	@Document(indexUid = "annotatedIdField")
 	static class AnnotatedIdField {
 
@@ -538,6 +553,57 @@ class MeilisearchTemplateIntegrationTests {
 
 		public void setName(String name) {
 			this.name = name;
+		}
+	}
+
+	@Document(indexUid = "nested-movies")
+	static class NestedMovie {
+
+		@Id private String id;
+		private String title;
+		private MovieDetails details;
+
+		@SuppressWarnings("unused")
+		NestedMovie() {}
+
+		NestedMovie(String id, String title, MovieDetails details) {
+			this.id = id;
+			this.title = title;
+			this.details = details;
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public MovieDetails getDetails() {
+			return details;
+		}
+	}
+
+	static class MovieDetails {
+
+		private String director;
+		private int year;
+
+		@SuppressWarnings("unused")
+		MovieDetails() {}
+
+		MovieDetails(String director, int year) {
+			this.director = director;
+			this.year = year;
+		}
+
+		public String getDirector() {
+			return director;
+		}
+
+		public int getYear() {
+			return year;
 		}
 	}
 

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverterUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverterUnitTests.java
@@ -17,10 +17,20 @@ package io.vanslog.spring.data.meilisearch.core.convert;
 
 import static org.assertj.core.api.Assertions.*;
 
+import io.vanslog.spring.data.meilisearch.annotations.Document;
+import io.vanslog.spring.data.meilisearch.core.document.MeilisearchDocument;
 import io.vanslog.spring.data.meilisearch.core.mapping.SimpleMeilisearchMappingContext;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.annotation.PersistenceCreator;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
 
 /**
  * Unit tests for {@link MappingMeilisearchConverter}.
@@ -44,5 +54,299 @@ class MappingMeilisearchConverterUnitTests {
 	@Test
 	void shouldReturnConversionService() {
 		assertThat(converter.getConversionService()).isNotNull();
+	}
+
+	@Test
+	void shouldWriteEntityPropertiesToDocument() {
+
+		SampleBook entity = new SampleBook("book-1", "The Left Hand of Darkness", 1969);
+		MeilisearchDocument document = MeilisearchDocument.create();
+
+		converter.write(entity, document);
+
+		assertThat(document).containsEntry("id", "book-1").containsEntry("title", "The Left Hand of Darkness")
+				.containsEntry("publishedYear", 1969);
+	}
+
+	@Test
+	void shouldReadEntityPropertiesFromDocument() {
+
+		MeilisearchDocument document = MeilisearchDocument.create().append("id", "book-2").append("title", "Kindred")
+				.append("publishedYear", 1979);
+
+		SampleBook entity = converter.read(SampleBook.class, document);
+
+		assertThat(entity.getId()).isEqualTo("book-2");
+		assertThat(entity.getTitle()).isEqualTo("Kindred");
+		assertThat(entity.getPublishedYear()).isEqualTo(1979);
+	}
+
+	@Test
+	void shouldRoundTripNestedObjectAsNestedDocument() {
+
+		BookWithAuthor source = new BookWithAuthor("book-3", "The Dispossessed", new Author("Ursula", "Le Guin"));
+		MeilisearchDocument document = MeilisearchDocument.create();
+
+		converter.write(source, document);
+
+		assertThat(document.get("author")).isEqualTo(MeilisearchDocument.create().append("firstName", "Ursula")
+				.append("lastName", "Le Guin"));
+
+		BookWithAuthor result = converter.read(BookWithAuthor.class, document);
+
+		assertThat(result.getTitle()).isEqualTo("The Dispossessed");
+		assertThat(result.getAuthor().getFirstName()).isEqualTo("Ursula");
+		assertThat(result.getAuthor().getLastName()).isEqualTo("Le Guin");
+	}
+
+	@Test
+	void shouldPreserveCollectionsAndNestedListElements() {
+
+		BookCollection source = new BookCollection("collection-1", List.of("science-fiction", "classic"),
+				List.of(new Author("Octavia", "Butler"), new Author("Nnedi", "Okorafor")));
+		MeilisearchDocument document = MeilisearchDocument.create();
+
+		converter.write(source, document);
+
+		assertThat(document.get("tags")).isEqualTo(List.of("science-fiction", "classic"));
+		assertThat(document.get("contributors")).isEqualTo(List.of(
+				MeilisearchDocument.create().append("firstName", "Octavia").append("lastName", "Butler"),
+				MeilisearchDocument.create().append("firstName", "Nnedi").append("lastName", "Okorafor")));
+
+		BookCollection result = converter.read(BookCollection.class, document);
+
+		assertThat(result.getTags()).containsExactly("science-fiction", "classic");
+		assertThat(result.getContributors()).extracting(Author::getLastName).containsExactly("Butler", "Okorafor");
+	}
+
+	@Test
+	void shouldApplyCustomWritingConversionToPropertyValues() {
+
+		registerPriceConversions();
+
+		PricedBook source = new PricedBook("book-4", new Price(new BigDecimal("12.99"), "USD"));
+		MeilisearchDocument document = MeilisearchDocument.create();
+
+		converter.write(source, document);
+
+		assertThat(document.get("price"))
+				.isEqualTo(MeilisearchDocument.create().append("amount", "12.99").append("currency", "USD"));
+	}
+
+	@Test
+	void shouldApplyCustomReadingConversionToPropertyValues() {
+
+		registerPriceConversions();
+
+		MeilisearchDocument document = MeilisearchDocument.create().append("id", "book-4").append("price",
+				MeilisearchDocument.create().append("amount", "12.99").append("currency", "USD"));
+
+		PricedBook result = converter.read(PricedBook.class, document);
+
+		assertThat(result.getPrice().getAmount()).isEqualByComparingTo("12.99");
+		assertThat(result.getPrice().getCurrency()).isEqualTo("USD");
+	}
+
+	@Test
+	void shouldReadConstructorBoundEntityPropertiesFromDocument() {
+
+		MeilisearchDocument document = MeilisearchDocument.create().append("id", "immutable-1")
+				.append("title", "Parable of the Sower");
+
+		ConstructorBoundBook result = converter.read(ConstructorBoundBook.class, document);
+
+		assertThat(result.getId()).isEqualTo("immutable-1");
+		assertThat(result.getTitle()).isEqualTo("Parable of the Sower");
+	}
+
+	private void registerPriceConversions() {
+
+		converter.setConversions(new MeilisearchCustomConversions(
+				List.of(new PriceToDocumentConverter(), new DocumentToPriceConverter())));
+		converter.afterPropertiesSet();
+	}
+
+	@Document(indexUid = "sample-books")
+	@SuppressWarnings("unused")
+	private static class SampleBook {
+
+		@Id private String id;
+		private String title;
+		private int publishedYear;
+
+		@SuppressWarnings("unused")
+		SampleBook() {}
+
+		SampleBook(String id, String title, int publishedYear) {
+			this.id = id;
+			this.title = title;
+			this.publishedYear = publishedYear;
+		}
+
+		String getId() {
+			return id;
+		}
+
+		String getTitle() {
+			return title;
+		}
+
+		int getPublishedYear() {
+			return publishedYear;
+		}
+	}
+
+	@Document(indexUid = "books-with-author")
+	@SuppressWarnings("unused")
+	private static class BookWithAuthor {
+
+		@Id private String id;
+		private String title;
+		private Author author;
+
+		@SuppressWarnings("unused")
+		BookWithAuthor() {}
+
+		BookWithAuthor(String id, String title, Author author) {
+			this.id = id;
+			this.title = title;
+			this.author = author;
+		}
+
+		Author getAuthor() {
+			return author;
+		}
+
+		String getTitle() {
+			return title;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	private static class Author {
+
+		private String firstName;
+		private String lastName;
+
+		@SuppressWarnings("unused")
+		Author() {}
+
+		Author(String firstName, String lastName) {
+			this.firstName = firstName;
+			this.lastName = lastName;
+		}
+
+		String getFirstName() {
+			return firstName;
+		}
+
+		String getLastName() {
+			return lastName;
+		}
+	}
+
+	@Document(indexUid = "book-collections")
+	@SuppressWarnings("unused")
+	private static class BookCollection {
+
+		@Id private String id;
+		private List<String> tags;
+		private List<Author> contributors;
+
+		@SuppressWarnings("unused")
+		BookCollection() {}
+
+		BookCollection(String id, List<String> tags, List<Author> contributors) {
+			this.id = id;
+			this.tags = tags;
+			this.contributors = contributors;
+		}
+
+		List<String> getTags() {
+			return tags;
+		}
+
+		List<Author> getContributors() {
+			return contributors;
+		}
+	}
+
+	@Document(indexUid = "priced-books")
+	@SuppressWarnings("unused")
+	private static class PricedBook {
+
+		@Id private String id;
+		private Price price;
+
+		@SuppressWarnings("unused")
+		PricedBook() {}
+
+		PricedBook(String id, Price price) {
+			this.id = id;
+			this.price = price;
+		}
+
+		Price getPrice() {
+			return price;
+		}
+	}
+
+	private static class Price {
+
+		private final BigDecimal amount;
+		private final String currency;
+
+		Price(BigDecimal amount, String currency) {
+			this.amount = amount;
+			this.currency = currency;
+		}
+
+		BigDecimal getAmount() {
+			return amount;
+		}
+
+		String getCurrency() {
+			return currency;
+		}
+	}
+
+	@Document(indexUid = "constructor-bound-books")
+	private static class ConstructorBoundBook {
+
+		@Id private final String id;
+		private final String title;
+
+		@PersistenceCreator
+		ConstructorBoundBook(String id, String title) {
+			this.id = id;
+			this.title = title;
+		}
+
+		String getId() {
+			return id;
+		}
+
+		String getTitle() {
+			return title;
+		}
+	}
+
+	@WritingConverter
+	private static class PriceToDocumentConverter implements Converter<Price, MeilisearchDocument> {
+
+		@Override
+		public MeilisearchDocument convert(Price source) {
+			return MeilisearchDocument.create().append("amount", source.getAmount().toPlainString()).append("currency",
+					source.getCurrency());
+		}
+	}
+
+	@ReadingConverter
+	private static class DocumentToPriceConverter implements Converter<MeilisearchDocument, Price> {
+
+		@Override
+		public Price convert(MeilisearchDocument source) {
+			return new Price(new BigDecimal((String) source.get("amount")), (String) source.get("currency"));
+		}
 	}
 }

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverterUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverterUnitTests.java
@@ -17,8 +17,7 @@ package io.vanslog.spring.data.meilisearch.core.convert;
 
 import static org.assertj.core.api.Assertions.*;
 
-import io.vanslog.spring.data.meilisearch.annotations.Document;
-import io.vanslog.spring.data.meilisearch.core.document.MeilisearchDocument;
+import io.vanslog.spring.data.meilisearch.core.document.Document;
 import io.vanslog.spring.data.meilisearch.core.mapping.SimpleMeilisearchMappingContext;
 
 import java.math.BigDecimal;
@@ -62,7 +61,7 @@ class MappingMeilisearchConverterUnitTests {
 	void shouldWriteEntityPropertiesToDocument() {
 
 		SampleBook entity = new SampleBook("book-1", "The Left Hand of Darkness", 1969);
-		MeilisearchDocument document = MeilisearchDocument.create();
+		Document document = Document.create();
 
 		converter.write(entity, document);
 
@@ -73,7 +72,7 @@ class MappingMeilisearchConverterUnitTests {
 	@Test
 	void shouldReadEntityPropertiesFromDocument() {
 
-		MeilisearchDocument document = MeilisearchDocument.create().append("id", "book-2").append("title", "Kindred")
+		Document document = Document.create().append("id", "book-2").append("title", "Kindred")
 				.append("publishedYear", 1979);
 
 		SampleBook entity = converter.read(SampleBook.class, document);
@@ -87,11 +86,11 @@ class MappingMeilisearchConverterUnitTests {
 	void shouldRoundTripNestedObjectAsNestedDocument() {
 
 		BookWithAuthor source = new BookWithAuthor("book-3", "The Dispossessed", new Author("Ursula", "Le Guin"));
-		MeilisearchDocument document = MeilisearchDocument.create();
+		Document document = Document.create();
 
 		converter.write(source, document);
 
-		assertThat(document.get("author")).isEqualTo(MeilisearchDocument.create().append("firstName", "Ursula")
+		assertThat(document.get("author")).isEqualTo(Document.create().append("firstName", "Ursula")
 				.append("lastName", "Le Guin"));
 
 		BookWithAuthor result = converter.read(BookWithAuthor.class, document);
@@ -106,14 +105,14 @@ class MappingMeilisearchConverterUnitTests {
 
 		BookCollection source = new BookCollection("collection-1", List.of("science-fiction", "classic"),
 				List.of(new Author("Octavia", "Butler"), new Author("Nnedi", "Okorafor")));
-		MeilisearchDocument document = MeilisearchDocument.create();
+		Document document = Document.create();
 
 		converter.write(source, document);
 
 		assertThat(document.get("tags")).isEqualTo(List.of("science-fiction", "classic"));
 		assertThat(document.get("contributors")).isEqualTo(List.of(
-				MeilisearchDocument.create().append("firstName", "Octavia").append("lastName", "Butler"),
-				MeilisearchDocument.create().append("firstName", "Nnedi").append("lastName", "Okorafor")));
+				Document.create().append("firstName", "Octavia").append("lastName", "Butler"),
+				Document.create().append("firstName", "Nnedi").append("lastName", "Okorafor")));
 
 		BookCollection result = converter.read(BookCollection.class, document);
 
@@ -124,7 +123,7 @@ class MappingMeilisearchConverterUnitTests {
 	@Test
 	void shouldMaterializeDeclaredSetPropertyWhenReadingDocument() {
 
-		MeilisearchDocument document = MeilisearchDocument.create().append("id", "set-1").append("tags",
+		Document document = Document.create().append("id", "set-1").append("tags",
 				List.of("science-fiction", "classic"));
 
 		BookTagSet result = converter.read(BookTagSet.class, document);
@@ -135,9 +134,9 @@ class MappingMeilisearchConverterUnitTests {
 	@Test
 	void shouldMaterializeDeclaredDequePropertyWithNestedElementsWhenReadingDocument() {
 
-		MeilisearchDocument document = MeilisearchDocument.create().append("id", "deque-1").append("contributors", List.of(
-				MeilisearchDocument.create().append("firstName", "Octavia").append("lastName", "Butler"),
-				MeilisearchDocument.create().append("firstName", "Nnedi").append("lastName", "Okorafor")));
+		Document document = Document.create().append("id", "deque-1").append("contributors", List.of(
+				Document.create().append("firstName", "Octavia").append("lastName", "Butler"),
+				Document.create().append("firstName", "Nnedi").append("lastName", "Okorafor")));
 
 		BookContributorDeque result = converter.read(BookContributorDeque.class, document);
 
@@ -151,12 +150,12 @@ class MappingMeilisearchConverterUnitTests {
 		registerPriceConversions();
 
 		PricedBook source = new PricedBook("book-4", new Price(new BigDecimal("12.99"), "USD"));
-		MeilisearchDocument document = MeilisearchDocument.create();
+		Document document = Document.create();
 
 		converter.write(source, document);
 
 		assertThat(document.get("price"))
-				.isEqualTo(MeilisearchDocument.create().append("amount", "12.99").append("currency", "USD"));
+				.isEqualTo(Document.create().append("amount", "12.99").append("currency", "USD"));
 	}
 
 	@Test
@@ -164,8 +163,8 @@ class MappingMeilisearchConverterUnitTests {
 
 		registerPriceConversions();
 
-		MeilisearchDocument document = MeilisearchDocument.create().append("id", "book-4").append("price",
-				MeilisearchDocument.create().append("amount", "12.99").append("currency", "USD"));
+		Document document = Document.create().append("id", "book-4").append("price",
+				Document.create().append("amount", "12.99").append("currency", "USD"));
 
 		PricedBook result = converter.read(PricedBook.class, document);
 
@@ -176,7 +175,7 @@ class MappingMeilisearchConverterUnitTests {
 	@Test
 	void shouldReadConstructorBoundEntityPropertiesFromDocument() {
 
-		MeilisearchDocument document = MeilisearchDocument.create().append("id", "immutable-1")
+		Document document = Document.create().append("id", "immutable-1")
 				.append("title", "Parable of the Sower");
 
 		ConstructorBoundBook result = converter.read(ConstructorBoundBook.class, document);
@@ -192,7 +191,7 @@ class MappingMeilisearchConverterUnitTests {
 		converter.afterPropertiesSet();
 	}
 
-	@Document(indexUid = "sample-books")
+	@io.vanslog.spring.data.meilisearch.annotations.Document(indexUid = "sample-books")
 	@SuppressWarnings("unused")
 	private static class SampleBook {
 
@@ -222,7 +221,7 @@ class MappingMeilisearchConverterUnitTests {
 		}
 	}
 
-	@Document(indexUid = "books-with-author")
+	@io.vanslog.spring.data.meilisearch.annotations.Document(indexUid = "books-with-author")
 	@SuppressWarnings("unused")
 	private static class BookWithAuthor {
 
@@ -271,7 +270,7 @@ class MappingMeilisearchConverterUnitTests {
 		}
 	}
 
-	@Document(indexUid = "book-collections")
+	@io.vanslog.spring.data.meilisearch.annotations.Document(indexUid = "book-collections")
 	@SuppressWarnings("unused")
 	private static class BookCollection {
 
@@ -297,7 +296,7 @@ class MappingMeilisearchConverterUnitTests {
 		}
 	}
 
-	@Document(indexUid = "book-tag-sets")
+	@io.vanslog.spring.data.meilisearch.annotations.Document(indexUid = "book-tag-sets")
 	@SuppressWarnings("unused")
 	private static class BookTagSet {
 
@@ -309,7 +308,7 @@ class MappingMeilisearchConverterUnitTests {
 		}
 	}
 
-	@Document(indexUid = "book-contributor-deques")
+	@io.vanslog.spring.data.meilisearch.annotations.Document(indexUid = "book-contributor-deques")
 	@SuppressWarnings("unused")
 	private static class BookContributorDeque {
 
@@ -321,7 +320,7 @@ class MappingMeilisearchConverterUnitTests {
 		}
 	}
 
-	@Document(indexUid = "priced-books")
+	@io.vanslog.spring.data.meilisearch.annotations.Document(indexUid = "priced-books")
 	@SuppressWarnings("unused")
 	private static class PricedBook {
 
@@ -360,7 +359,7 @@ class MappingMeilisearchConverterUnitTests {
 		}
 	}
 
-	@Document(indexUid = "constructor-bound-books")
+	@io.vanslog.spring.data.meilisearch.annotations.Document(indexUid = "constructor-bound-books")
 	private static class ConstructorBoundBook {
 
 		@Id private final String id;
@@ -382,20 +381,20 @@ class MappingMeilisearchConverterUnitTests {
 	}
 
 	@WritingConverter
-	private static class PriceToDocumentConverter implements Converter<Price, MeilisearchDocument> {
+	private static class PriceToDocumentConverter implements Converter<Price, Document> {
 
 		@Override
-		public MeilisearchDocument convert(Price source) {
-			return MeilisearchDocument.create().append("amount", source.getAmount().toPlainString()).append("currency",
+		public Document convert(Price source) {
+			return Document.create().append("amount", source.getAmount().toPlainString()).append("currency",
 					source.getCurrency());
 		}
 	}
 
 	@ReadingConverter
-	private static class DocumentToPriceConverter implements Converter<MeilisearchDocument, Price> {
+	private static class DocumentToPriceConverter implements Converter<Document, Price> {
 
 		@Override
-		public Price convert(MeilisearchDocument source) {
+		public Price convert(Document source) {
 			return new Price(new BigDecimal((String) source.get("amount")), (String) source.get("currency"));
 		}
 	}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverterUnitTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/core/convert/MappingMeilisearchConverterUnitTests.java
@@ -22,7 +22,9 @@ import io.vanslog.spring.data.meilisearch.core.document.MeilisearchDocument;
 import io.vanslog.spring.data.meilisearch.core.mapping.SimpleMeilisearchMappingContext;
 
 import java.math.BigDecimal;
+import java.util.Deque;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -116,6 +118,30 @@ class MappingMeilisearchConverterUnitTests {
 		BookCollection result = converter.read(BookCollection.class, document);
 
 		assertThat(result.getTags()).containsExactly("science-fiction", "classic");
+		assertThat(result.getContributors()).extracting(Author::getLastName).containsExactly("Butler", "Okorafor");
+	}
+
+	@Test
+	void shouldMaterializeDeclaredSetPropertyWhenReadingDocument() {
+
+		MeilisearchDocument document = MeilisearchDocument.create().append("id", "set-1").append("tags",
+				List.of("science-fiction", "classic"));
+
+		BookTagSet result = converter.read(BookTagSet.class, document);
+
+		assertThat(result.getTags()).containsExactly("science-fiction", "classic");
+	}
+
+	@Test
+	void shouldMaterializeDeclaredDequePropertyWithNestedElementsWhenReadingDocument() {
+
+		MeilisearchDocument document = MeilisearchDocument.create().append("id", "deque-1").append("contributors", List.of(
+				MeilisearchDocument.create().append("firstName", "Octavia").append("lastName", "Butler"),
+				MeilisearchDocument.create().append("firstName", "Nnedi").append("lastName", "Okorafor")));
+
+		BookContributorDeque result = converter.read(BookContributorDeque.class, document);
+
+		assertThat(result.getContributors()).isInstanceOf(Deque.class);
 		assertThat(result.getContributors()).extracting(Author::getLastName).containsExactly("Butler", "Okorafor");
 	}
 
@@ -267,6 +293,30 @@ class MappingMeilisearchConverterUnitTests {
 		}
 
 		List<Author> getContributors() {
+			return contributors;
+		}
+	}
+
+	@Document(indexUid = "book-tag-sets")
+	@SuppressWarnings("unused")
+	private static class BookTagSet {
+
+		@Id private String id;
+		private Set<String> tags;
+
+		Set<String> getTags() {
+			return tags;
+		}
+	}
+
+	@Document(indexUid = "book-contributor-deques")
+	@SuppressWarnings("unused")
+	private static class BookContributorDeque {
+
+		@Id private String id;
+		private Deque<Author> contributors;
+
+		Deque<Author> getContributors() {
 			return contributors;
 		}
 	}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/entities/Movie.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/entities/Movie.java
@@ -86,11 +86,10 @@ public class Movie {
 			return true;
 		}
 
-		if (object == null || getClass() != object.getClass()) {
+		if (!(object instanceof Movie movie) || getClass() != movie.getClass()) {
 			return false;
 		}
 
-		Movie movie = (Movie) object;
 		return id == movie.id && Objects.equals(title, movie.title) && Objects.equals(description, movie.description)
 				&& Arrays.equals(genres, movie.genres);
 	}

--- a/src/test/java/io/vanslog/spring/data/meilisearch/repository/MeilisearchRepositoryIntegrationTests.java
+++ b/src/test/java/io/vanslog/spring/data/meilisearch/repository/MeilisearchRepositoryIntegrationTests.java
@@ -17,6 +17,7 @@ package io.vanslog.spring.data.meilisearch.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import io.vanslog.spring.data.meilisearch.annotations.Document;
 import io.vanslog.spring.data.meilisearch.entities.Movie;
 import io.vanslog.spring.data.meilisearch.entities.TotalHitsLimited;
 import io.vanslog.spring.data.meilisearch.junit.jupiter.MeilisearchTest;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ContextConfiguration;
@@ -46,11 +48,13 @@ class MeilisearchRepositoryIntegrationTests {
 
 	@Autowired private MovieRepository movieRepository;
 	@Autowired private TotalHitsLimitedRepository totalHitsLimitedRepository;
+	@Autowired private NestedMovieRepository nestedMovieRepository;
 
 	@BeforeEach
 	void setUp() {
 		movieRepository.deleteAll();
 		totalHitsLimitedRepository.deleteAll();
+		nestedMovieRepository.deleteAll();
 	}
 
 	@Test
@@ -69,6 +73,22 @@ class MeilisearchRepositoryIntegrationTests {
 		// then
 		Optional<Movie> saved = movieRepository.findById(documentId);
 		assertThat(saved).isPresent();
+	}
+
+	@Test
+	void shouldFindNestedDocumentByIdThroughRepository() {
+		// given
+		NestedMovie nestedMovie = new NestedMovie("nested-1", "Nested Search", new MovieDetails("Director", 2026));
+
+		// when
+		nestedMovieRepository.save(nestedMovie);
+
+		// then
+		Optional<NestedMovie> saved = nestedMovieRepository.findById("nested-1");
+		assertThat(saved).isPresent();
+		assertThat(saved.get().getDetails()).isNotNull();
+		assertThat(saved.get().getDetails().getDirector()).isEqualTo("Director");
+		assertThat(saved.get().getDetails().getYear()).isEqualTo(2026);
 	}
 
 	@Test
@@ -327,6 +347,59 @@ class MeilisearchRepositoryIntegrationTests {
 	interface MovieRepository extends MeilisearchRepository<Movie, Integer> {}
 
 	interface TotalHitsLimitedRepository extends MeilisearchRepository<TotalHitsLimited, String> {}
+
+	interface NestedMovieRepository extends MeilisearchRepository<NestedMovie, String> {}
+
+	@Document(indexUid = "nested-movies")
+	static class NestedMovie {
+
+		@Id private String id;
+		private String title;
+		private MovieDetails details;
+
+		@SuppressWarnings("unused")
+		NestedMovie() {}
+
+		NestedMovie(String id, String title, MovieDetails details) {
+			this.id = id;
+			this.title = title;
+			this.details = details;
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public MovieDetails getDetails() {
+			return details;
+		}
+	}
+
+	static class MovieDetails {
+
+		private String director;
+		private int year;
+
+		@SuppressWarnings("unused")
+		MovieDetails() {}
+
+		MovieDetails(String director, int year) {
+			this.director = director;
+			this.year = year;
+		}
+
+		public String getDirector() {
+			return director;
+		}
+
+		public int getYear() {
+			return year;
+		}
+	}
 
 	@Configuration
 	@Import(MeilisearchTestConfiguration.class)

--- a/src/test/resources/io/vanslog/spring/data/meilisearch/config/namespace.xml
+++ b/src/test/resources/io/vanslog/spring/data/meilisearch/config/namespace.xml
@@ -10,7 +10,27 @@
     <bean name="meilisearchTemplate"
           class="io.vanslog.spring.data.meilisearch.client.msc.MeilisearchTemplate">
         <constructor-arg name="meilisearchClient" ref="meilisearchClient"/>
+        <constructor-arg name="meilisearchConverter" ref="meilisearchConverter"/>
+        <constructor-arg name="objectMapper" ref="meilisearchObjectMapper"/>
     </bean>
+
+    <bean id="meilisearchConverter"
+          class="io.vanslog.spring.data.meilisearch.core.convert.MappingMeilisearchConverter">
+        <constructor-arg name="mappingContext" ref="meilisearchMappingContext"/>
+        <property name="conversions" ref="meilisearchCustomConversions"/>
+    </bean>
+
+    <bean id="meilisearchMappingContext"
+          class="io.vanslog.spring.data.meilisearch.core.mapping.SimpleMeilisearchMappingContext"/>
+
+    <bean id="meilisearchCustomConversions"
+          class="io.vanslog.spring.data.meilisearch.core.convert.MeilisearchCustomConversions">
+        <constructor-arg>
+            <list/>
+        </constructor-arg>
+    </bean>
+
+    <bean id="meilisearchObjectMapper" class="com.fasterxml.jackson.databind.ObjectMapper"/>
 
     <meilisearch:repositories
             base-package="io.vanslog.spring.data.meilisearch.config"


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/junghoon-vans/spring-data-meilisearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #108
Closes #112

## Summary
- Add `Document` and make `MappingMeilisearchConverter` read/write mapped document payloads, including nested values, collections, custom conversions, IDs, and constructor-bound entities.
- Route template document operations and supported search/facet paths through Spring-managed conversion plus raw SDK JSON APIs.
- Register `meilisearchObjectMapper` for document payload serialization and align JavaConfig, XML fixture wiring, tests, and reference docs.

## Verification
- `./mvnw clean -Dtest=MappingMeilisearchConverterUnitTests test`
- `./mvnw -Dtest=MeilisearchRepositoryIntegrationTests test`
- `./mvnw test`
- `./mvnw verify -Pci`

## Notes
- `JsonHandler` remains the SDK transport JSON integration point; entity document payloads are handled by `MeilisearchConverter` and `meilisearchObjectMapper`.
- Local `./mvnw verify -Pci` was run with ignored `.playwright-mcp` artifacts temporarily moved out of the working tree, then restored.



## Summary by CodeRabbit

* **New Features**
  * Configurable `ObjectMapper` for JSON serialization of Meilisearch documents
  * Improved nested document mapping and round-trip support
  * Enhanced facet search result handling

* **Documentation**
  * Updated guides on document mapping, JSON payload handling, and `ObjectMapper` configuration
  * Clarified Spring Data Meilisearch&#39;s entity-to-document conversion flow
  * Enhanced XML namespace configuration examples with converter and mapper setup



[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/junghoon-vans/spring-data-meilisearch/pull/209?utm_source=github_walkthrough&amp;utm_medium=github&amp;utm_campaign=change_stack)



