### PR TITLE
Exclude actions bot from release draft contributors.

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,6 +12,7 @@ categories:
 
 exclude-contributors:
   - 'junghoon-vans'
+  - 'github-actions[bot]'
 
 change-template: '* $TITLE #$NUMBER'
 template: |


### PR DESCRIPTION
## Summary
- Exclude github-actions[bot] from Release Drafter's generated contributors list.

## Verification
- ruby -e 'require "yaml"; config = YAML.load_file(".github/release-drafter.yml"); contributors = config.fetch("exclude-contributors"); abort("github-actions[bot] is not excluded") unless contributors.include?("github-actions[bot]"); puts "github-actions[bot] is excluded"'
- YAML diagnostics: clean

## Issue
- No existing issue found for this maintenance-only release-drafter cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release notes generation by refining contributor attribution to focus on human contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->