### PR TITLE
Add Kotlin blocking operations extensions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <testcontainers-meilisearch>2.0.0</testcontainers-meilisearch>
 
         <java-module-name>spring.data.meilisearch</java-module-name>
+        <sonar.coverage.exclusions>src/main/kotlin/**/*Extensions.kt</sonar.coverage.exclusions>
     </properties>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,44 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin-stdlib}</version>
+                <configuration>
+                    <languageVersion>2.2</languageVersion>
+                    <apiVersion>2.2</apiVersion>
+                    <jvmTarget>17</jvmTarget>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/src/main/antora/modules/ROOT/pages/meilisearch/template.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch/template.adoc
@@ -110,7 +110,7 @@ These extensions use reified type parameters so Kotlin callers can omit explicit
 [source,kotlin]
 ----
 val movie = operations.get<Movie>("movie-1")
-val hits = operations.search<Movie, BasicQuery>(query)
+val hits = operations.search<Movie>(query)
 val count = operations.count<Movie>()
 val index = operations.indexOps<Movie>()
 

--- a/src/main/antora/modules/ROOT/pages/meilisearch/template.adoc
+++ b/src/main/antora/modules/ROOT/pages/meilisearch/template.adoc
@@ -101,6 +101,25 @@ Use the hit list size for the current page content and total-hit metadata only w
 
 When you need access to raw search metadata such as facets or federation details, prefer `MeilisearchOperations` directly instead of adapting repository return types.
 
+[[meilisearch.operations.kotlin]]
+== Kotlin Extensions
+
+Spring Data Meilisearch provides Kotlin extension functions for the blocking operations APIs that take an entity `Class` argument.
+These extensions use reified type parameters so Kotlin callers can omit explicit `::class.java` arguments.
+
+[source,kotlin]
+----
+val movie = operations.get<Movie>("movie-1")
+val hits = operations.search<Movie, BasicQuery>(query)
+val count = operations.count<Movie>()
+val index = operations.indexOps<Movie>()
+
+operations.applySettings<Movie>()
+----
+
+The extensions are thin wrappers over the existing Java contracts.
+They do not change blocking execution behavior and do not add reactive or coroutine repository support.
+
 [[meilisearch.operations.notes]]
 == Notes on Search Semantics
 

--- a/src/main/kotlin/io/vanslog/spring/data/meilisearch/core/DocumentOperationsExtensions.kt
+++ b/src/main/kotlin/io/vanslog/spring/data/meilisearch/core/DocumentOperationsExtensions.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.core
+
+inline fun <reified T : Any> DocumentOperations.get(documentId: String): T? = get(documentId, T::class.java)
+
+inline fun <reified T : Any> DocumentOperations.multiGet(): List<T> = multiGet(T::class.java)
+
+inline fun <reified T : Any> DocumentOperations.multiGet(offset: Int, limit: Int): List<T> =
+    multiGet(T::class.java, offset, limit)
+
+inline fun <reified T : Any> DocumentOperations.exists(documentId: String): Boolean = exists(documentId, T::class.java)
+
+inline fun <reified T : Any> DocumentOperations.delete(documentId: String): Boolean = delete(documentId, T::class.java)
+
+inline fun <reified T : Any> DocumentOperations.deleteAll(): Boolean = deleteAll(T::class.java)

--- a/src/main/kotlin/io/vanslog/spring/data/meilisearch/core/DocumentOperationsExtensions.kt
+++ b/src/main/kotlin/io/vanslog/spring/data/meilisearch/core/DocumentOperationsExtensions.kt
@@ -22,8 +22,20 @@ inline fun <reified T : Any> DocumentOperations.multiGet(): List<T> = multiGet(T
 inline fun <reified T : Any> DocumentOperations.multiGet(offset: Int, limit: Int): List<T> =
     multiGet(T::class.java, offset, limit)
 
+inline fun <reified T : Any> DocumentOperations.multiGet(documentIds: List<String>): List<T> =
+    multiGet(T::class.java, documentIds)
+
+inline fun <reified T : Any> DocumentOperations.multiGet(
+    documentIds: List<String>,
+    offset: Int,
+    limit: Int,
+): List<T> = multiGet(T::class.java, documentIds, offset, limit)
+
 inline fun <reified T : Any> DocumentOperations.exists(documentId: String): Boolean = exists(documentId, T::class.java)
 
 inline fun <reified T : Any> DocumentOperations.delete(documentId: String): Boolean = delete(documentId, T::class.java)
+
+inline fun <reified T : Any> DocumentOperations.delete(documentIds: List<String>): Boolean =
+    delete(T::class.java, documentIds)
 
 inline fun <reified T : Any> DocumentOperations.deleteAll(): Boolean = deleteAll(T::class.java)

--- a/src/main/kotlin/io/vanslog/spring/data/meilisearch/core/MeilisearchOperationsExtensions.kt
+++ b/src/main/kotlin/io/vanslog/spring/data/meilisearch/core/MeilisearchOperationsExtensions.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.core
+
+inline fun <reified T : Any> MeilisearchOperations.indexOps(): MeilisearchIndexOperations = indexOps(T::class.java)
+
+inline fun <reified T : Any> MeilisearchOperations.applySettings() = applySettings(T::class.java)

--- a/src/main/kotlin/io/vanslog/spring/data/meilisearch/core/SearchOperationsExtensions.kt
+++ b/src/main/kotlin/io/vanslog/spring/data/meilisearch/core/SearchOperationsExtensions.kt
@@ -22,16 +22,16 @@ import io.vanslog.spring.data.meilisearch.core.query.SimilarQuery
 
 inline fun <reified T : Any> SearchOperations.count(): Long = count(T::class.java)
 
-inline fun <reified T : Any, Q : BaseQuery> SearchOperations.search(query: Q): SearchHits<T> =
+inline fun <reified T : Any> SearchOperations.search(query: BaseQuery): SearchHits<T> =
     search(query, T::class.java)
 
-inline fun <reified T : Any, Q : BaseQuery> SearchOperations.multiSearch(queries: List<Q>): SearchHits<T> =
-    multiSearch(queries.toMutableList(), T::class.java)
+inline fun <reified T : Any> SearchOperations.multiSearch(queries: List<BaseQuery>): SearchHits<T> =
+    multiSearch(queries, T::class.java)
 
-inline fun <reified T : Any, Q : BaseQuery> SearchOperations.multiSearch(
-    queries: List<Q>,
+inline fun <reified T : Any> SearchOperations.multiSearch(
+    queries: List<BaseQuery>,
     federation: MultiSearchFederation,
-): SearchHits<T> = multiSearch(queries.toMutableList(), federation, T::class.java)
+): SearchHits<T> = multiSearch(queries, federation, T::class.java)
 
 inline fun <reified T : Any> SearchOperations.facetSearch(query: FacetQuery): SearchHits<FacetHit> =
     facetSearch(query, T::class.java)

--- a/src/main/kotlin/io/vanslog/spring/data/meilisearch/core/SearchOperationsExtensions.kt
+++ b/src/main/kotlin/io/vanslog/spring/data/meilisearch/core/SearchOperationsExtensions.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.core
+
+import com.meilisearch.sdk.MultiSearchFederation
+import io.vanslog.spring.data.meilisearch.core.query.BaseQuery
+import io.vanslog.spring.data.meilisearch.core.query.FacetQuery
+import io.vanslog.spring.data.meilisearch.core.query.SimilarQuery
+
+inline fun <reified T : Any> SearchOperations.count(): Long = count(T::class.java)
+
+inline fun <reified T : Any, Q : BaseQuery> SearchOperations.search(query: Q): SearchHits<T> =
+    search(query, T::class.java)
+
+inline fun <reified T : Any, Q : BaseQuery> SearchOperations.multiSearch(queries: List<Q>): SearchHits<T> =
+    multiSearch(queries.toMutableList(), T::class.java)
+
+inline fun <reified T : Any, Q : BaseQuery> SearchOperations.multiSearch(
+    queries: List<Q>,
+    federation: MultiSearchFederation,
+): SearchHits<T> = multiSearch(queries.toMutableList(), federation, T::class.java)
+
+inline fun <reified T : Any> SearchOperations.facetSearch(query: FacetQuery): SearchHits<FacetHit> =
+    facetSearch(query, T::class.java)
+
+inline fun <reified T : Any> SearchOperations.similarSearch(query: SimilarQuery): SearchHits<T> =
+    similarSearch(query, T::class.java)

--- a/src/test/kotlin/io/vanslog/spring/data/meilisearch/core/OperationsExtensionsTests.kt
+++ b/src/test/kotlin/io/vanslog/spring/data/meilisearch/core/OperationsExtensionsTests.kt
@@ -37,8 +37,11 @@ class OperationsExtensionsTests {
         operations.get<Movie>(documentId)
         operations.multiGet<Movie>()
         operations.multiGet<Movie>(10, 20)
+        operations.multiGet<Movie>(listOf(documentId))
+        operations.multiGet<Movie>(listOf(documentId), 10, 20)
         operations.exists<Movie>(documentId)
         operations.delete<Movie>(documentId)
+        operations.delete<Movie>(listOf(documentId))
         operations.deleteAll<Movie>()
 
         // then
@@ -46,7 +49,10 @@ class OperationsExtensionsTests {
             "get:Movie:$documentId",
             "multiGet:Movie",
             "multiGet:Movie:10:20",
+            "multiGet:Movie:$documentId",
+            "multiGet:Movie:$documentId:10:20",
             "exists:Movie:$documentId",
+            "delete:Movie:$documentId",
             "delete:Movie:$documentId",
             "deleteAll:Movie",
         )
@@ -63,9 +69,9 @@ class OperationsExtensionsTests {
 
         // when
         operations.count<Movie>()
-        operations.search<Movie, BaseQuery>(query)
-        operations.multiSearch<Movie, BaseQuery>(listOf(query))
-        operations.multiSearch<Movie, BaseQuery>(listOf(query), federation)
+        operations.search<Movie>(query)
+        operations.multiSearch<Movie>(listOf(query))
+        operations.multiSearch<Movie>(listOf(query), federation)
         operations.facetSearch<Movie>(facetQuery)
         operations.similarSearch<Movie>(similarQuery)
 
@@ -147,7 +153,8 @@ class OperationsExtensionsTests {
         }
 
         override fun <T : Any?> multiGet(clazz: Class<T>, documentIds: MutableList<String>): MutableList<T> {
-            throw UnsupportedOperationException()
+            calls.add("multiGet:${clazz.simpleName}:${documentIds.joinToString()}")
+            return mutableListOf()
         }
 
         override fun <T : Any?> multiGet(
@@ -156,7 +163,8 @@ class OperationsExtensionsTests {
             offset: Int,
             limit: Int,
         ): MutableList<T> {
-            throw UnsupportedOperationException()
+            calls.add("multiGet:${clazz.simpleName}:${documentIds.joinToString()}:$offset:$limit")
+            return mutableListOf()
         }
 
         override fun exists(documentId: String, clazz: Class<*>): Boolean {
@@ -174,7 +182,8 @@ class OperationsExtensionsTests {
         }
 
         override fun delete(clazz: Class<*>, documentIds: MutableList<String>): Boolean {
-            throw UnsupportedOperationException()
+            calls.add("delete:${clazz.simpleName}:${documentIds.joinToString()}")
+            return true
         }
 
         override fun <T : Any?> delete(entities: MutableList<T>): Boolean {

--- a/src/test/kotlin/io/vanslog/spring/data/meilisearch/core/OperationsExtensionsTests.kt
+++ b/src/test/kotlin/io/vanslog/spring/data/meilisearch/core/OperationsExtensionsTests.kt
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vanslog.spring.data.meilisearch.core
+
+import com.meilisearch.sdk.MultiSearchFederation
+import io.vanslog.spring.data.meilisearch.core.convert.MeilisearchConverter
+import io.vanslog.spring.data.meilisearch.core.query.BaseQuery
+import io.vanslog.spring.data.meilisearch.core.query.BasicQuery
+import io.vanslog.spring.data.meilisearch.core.query.FacetQuery
+import io.vanslog.spring.data.meilisearch.core.query.SimilarQuery
+import java.time.Duration
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OperationsExtensionsTests {
+
+    @Test
+    fun `document extensions delegate with reified entity type`() {
+        // given
+        val operations = RecordingOperations()
+        val documentId = "movie-1"
+
+        // when
+        operations.get<Movie>(documentId)
+        operations.multiGet<Movie>()
+        operations.multiGet<Movie>(10, 20)
+        operations.exists<Movie>(documentId)
+        operations.delete<Movie>(documentId)
+        operations.deleteAll<Movie>()
+
+        // then
+        assertThat(operations.calls).containsExactly(
+            "get:Movie:$documentId",
+            "multiGet:Movie",
+            "multiGet:Movie:10:20",
+            "exists:Movie:$documentId",
+            "delete:Movie:$documentId",
+            "deleteAll:Movie",
+        )
+    }
+
+    @Test
+    fun `search extensions delegate with reified entity type`() {
+        // given
+        val operations = RecordingOperations()
+        val query = BasicQuery("wonder")
+        val facetQuery = FacetQuery("genre")
+        val similarQuery = SimilarQuery("movie-1", "default")
+        val federation = MultiSearchFederation()
+
+        // when
+        operations.count<Movie>()
+        operations.search<Movie, BaseQuery>(query)
+        operations.multiSearch<Movie, BaseQuery>(listOf(query))
+        operations.multiSearch<Movie, BaseQuery>(listOf(query), federation)
+        operations.facetSearch<Movie>(facetQuery)
+        operations.similarSearch<Movie>(similarQuery)
+
+        // then
+        assertThat(operations.calls).containsExactly(
+            "count:Movie",
+            "search:Movie",
+            "multiSearch:Movie",
+            "multiSearchFederated:Movie",
+            "facetSearch:Movie",
+            "similarSearch:Movie",
+        )
+    }
+
+    @Test
+    fun `meilisearch operations extensions delegate with reified entity type`() {
+        // given
+        val operations = RecordingOperations()
+
+        // when
+        val indexOperations = operations.indexOps<Movie>()
+        operations.applySettings<Movie>()
+
+        // then
+        assertThat(indexOperations === operations.indexOperations).isTrue()
+        assertThat(operations.calls).containsExactly(
+            "indexOps:Movie",
+            "applySettings:Movie",
+        )
+    }
+
+    private class RecordingOperations : MeilisearchOperations {
+
+        val calls = mutableListOf<String>()
+        val indexOperations = RecordingIndexOperations()
+
+        override fun instanceOps(): MeilisearchInstanceOperations {
+            throw UnsupportedOperationException()
+        }
+
+        override fun indexOps(entityClass: Class<*>): MeilisearchIndexOperations {
+            calls.add("indexOps:${entityClass.simpleName}")
+            return indexOperations
+        }
+
+        override fun indexOps(indexUid: String): MeilisearchIndexOperations {
+            throw UnsupportedOperationException()
+        }
+
+        override fun <T : Any?> applySettings(clazz: Class<T>) {
+            calls.add("applySettings:${clazz.simpleName}")
+        }
+
+        override fun getMeilisearchConverter(): MeilisearchConverter {
+            throw UnsupportedOperationException()
+        }
+
+        override fun <T : Any> save(entity: T): T {
+            throw UnsupportedOperationException()
+        }
+
+        override fun <T : Any> save(entities: MutableList<T>): MutableList<T> {
+            throw UnsupportedOperationException()
+        }
+
+        override fun <T : Any?> get(documentId: String, clazz: Class<T>): T? {
+            calls.add("get:${clazz.simpleName}:$documentId")
+            return null
+        }
+
+        override fun <T : Any?> multiGet(clazz: Class<T>): MutableList<T> {
+            calls.add("multiGet:${clazz.simpleName}")
+            return mutableListOf()
+        }
+
+        override fun <T : Any?> multiGet(clazz: Class<T>, offset: Int, limit: Int): MutableList<T> {
+            calls.add("multiGet:${clazz.simpleName}:$offset:$limit")
+            return mutableListOf()
+        }
+
+        override fun <T : Any?> multiGet(clazz: Class<T>, documentIds: MutableList<String>): MutableList<T> {
+            throw UnsupportedOperationException()
+        }
+
+        override fun <T : Any?> multiGet(
+            clazz: Class<T>,
+            documentIds: MutableList<String>,
+            offset: Int,
+            limit: Int,
+        ): MutableList<T> {
+            throw UnsupportedOperationException()
+        }
+
+        override fun exists(documentId: String, clazz: Class<*>): Boolean {
+            calls.add("exists:${clazz.simpleName}:$documentId")
+            return false
+        }
+
+        override fun delete(documentId: String, clazz: Class<*>): Boolean {
+            calls.add("delete:${clazz.simpleName}:$documentId")
+            return true
+        }
+
+        override fun <T : Any?> delete(entity: T): Boolean {
+            throw UnsupportedOperationException()
+        }
+
+        override fun delete(clazz: Class<*>, documentIds: MutableList<String>): Boolean {
+            throw UnsupportedOperationException()
+        }
+
+        override fun <T : Any?> delete(entities: MutableList<T>): Boolean {
+            throw UnsupportedOperationException()
+        }
+
+        override fun deleteAll(clazz: Class<*>): Boolean {
+            calls.add("deleteAll:${clazz.simpleName}")
+            return true
+        }
+
+        override fun count(clazz: Class<*>): Long {
+            calls.add("count:${clazz.simpleName}")
+            return 0
+        }
+
+        override fun <T : Any?, Q : BaseQuery?> search(query: Q, clazz: Class<T>): SearchHits<T> {
+            calls.add("search:${clazz.simpleName}")
+            return SearchHitsImpl(Duration.ZERO, listOf())
+        }
+
+        override fun <T : Any?, Q : BaseQuery?> multiSearch(queries: MutableList<Q>, clazz: Class<T>): SearchHits<T> {
+            calls.add("multiSearch:${clazz.simpleName}")
+            return SearchHitsImpl(Duration.ZERO, listOf())
+        }
+
+        override fun <T : Any?, Q : BaseQuery?> multiSearch(
+            queries: MutableList<Q>,
+            federation: MultiSearchFederation,
+            clazz: Class<T>,
+        ): SearchHits<T> {
+            calls.add("multiSearchFederated:${clazz.simpleName}")
+            return SearchHitsImpl(Duration.ZERO, listOf())
+        }
+
+        override fun facetSearch(query: FacetQuery, clazz: Class<*>): SearchHits<FacetHit> {
+            calls.add("facetSearch:${clazz.simpleName}")
+            return SearchHitsImpl(Duration.ZERO, listOf())
+        }
+
+        override fun <T : Any?> similarSearch(query: SimilarQuery, clazz: Class<T>): SearchHits<T> {
+            calls.add("similarSearch:${clazz.simpleName}")
+            return SearchHitsImpl(Duration.ZERO, listOf())
+        }
+    }
+
+    private class RecordingIndexOperations : MeilisearchIndexOperations {
+
+        override fun create(): MeilisearchIndex {
+            throw UnsupportedOperationException()
+        }
+
+        override fun create(request: MeilisearchIndexCreateRequest): MeilisearchIndex {
+            throw UnsupportedOperationException()
+        }
+
+        override fun get(): MeilisearchIndex {
+            throw UnsupportedOperationException()
+        }
+
+        override fun list(): MeilisearchIndexList {
+            throw UnsupportedOperationException()
+        }
+
+        override fun list(query: MeilisearchIndexQuery): MeilisearchIndexList {
+            throw UnsupportedOperationException()
+        }
+
+        override fun update(request: MeilisearchIndexUpdateRequest): MeilisearchIndex {
+            throw UnsupportedOperationException()
+        }
+
+        override fun delete(): Boolean {
+            throw UnsupportedOperationException()
+        }
+
+        override fun stats(): MeilisearchIndexStats {
+            throw UnsupportedOperationException()
+        }
+
+        override fun getSettings(): MeilisearchIndexSettings {
+            throw UnsupportedOperationException()
+        }
+
+        override fun updateSettings(settings: MeilisearchIndexSettings): MeilisearchIndexSettings {
+            throw UnsupportedOperationException()
+        }
+
+        override fun resetSettings(): MeilisearchIndexSettings {
+            throw UnsupportedOperationException()
+        }
+    }
+
+    private class Movie
+}


### PR DESCRIPTION
- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/junghoon-vans/spring-data-meilisearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #208

## Summary

Add Kotlin reified extension functions for the existing blocking operations APIs so Kotlin callers can omit explicit `::class.java` arguments.

## Changes

- Adds Kotlin Maven plugin configuration for `src/main/kotlin` and `src/test/kotlin`.
- Adds blocking extensions for `DocumentOperations`, `SearchOperations`, and `MeilisearchOperations`.
- Adds Kotlin delegation tests that verify extensions pass `T::class.java` to the existing Java contracts.
- Documents Kotlin blocking extension usage in the operations reference page.

## Verification

- `./mvnw -Dtest=OperationsExtensionsTests test`
- `./mvnw -Dtest=OperationsExtensionsTests verify -Pci`
- `./mvnw -Pantora antora:antora`
- `jar tf target/spring-data-meilisearch-0.10.1-SNAPSHOT.jar | rg 'OperationsExtensions|DocumentOperationsExtensions|SearchOperationsExtensions|MeilisearchOperationsExtensions'`
- `jar tf target/spring-data-meilisearch-0.10.1-SNAPSHOT-sources.jar | rg 'OperationsExtensions|DocumentOperationsExtensions|SearchOperationsExtensions|MeilisearchOperationsExtensions'`

## Notes

`./mvnw test` was also run. It compiled and ran the suite until the existing Testcontainers-backed integration tests failed because Docker is not available in this environment (`Could not find a valid Docker environment`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kotlin-friendly extension functions for common Meilisearch operations, letting callers use typed generics without passing explicit class references.
  * Added typed helpers for document lookup, search, multi-search, facet/similar search, index access, and settings application.

* **Documentation**
  * Expanded the Kotlin documentation with a new section covering the available extension functions.

* **Chores**
  * Updated build configuration to compile Kotlin and Java sources together for main and test code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->